### PR TITLE
Fix #65 : Manage pattern file name in command line argument.

### DIFF
--- a/fr.cnes.icode.application/META-INF/MANIFEST.MF
+++ b/fr.cnes.icode.application/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Require-Bundle: org.eclipse.core.runtime,
  fr.cnes.analysis.tools.fortran90.rules;bundle-version="2.0.0",
  fr.cnes.analysis.tools.shell.metrics;bundle-version="2.0.0",
  fr.cnes.analysis.tools.shell.rules;bundle-version="2.0.0"
+Import-Package: org.apache.tools.ant

--- a/fr.cnes.icode.feature.core/feature.xml
+++ b/fr.cnes.icode.feature.core/feature.xml
@@ -118,6 +118,7 @@ This Agreement is governed by the laws of the State of New York and the intellec
       <import plugin="fr.cnes.analysis.tools.fortran90.rules" version="2.0.0" match="greaterOrEqual"/>
       <import plugin="fr.cnes.analysis.tools.shell.metrics" version="2.0.0" match="greaterOrEqual"/>
       <import plugin="fr.cnes.analysis.tools.shell.rules" version="2.0.0" match="greaterOrEqual"/>
+      <import plugin="org.apache.ant"/>
    </requires>
 
    <plugin


### PR DESCRIPTION
Files can be either absolute paths or patterns like : 

   icode *.f90 ~/tmp/**/*.f77 /tmp/myfile.f77

** is used to manage the recursive folder browsing


Change-Id: I860c00528c7c249785efdd2cff5edaeff5ec9d1c
Signed-off-by: Olivier Prouvost <olivier.prouvost@opcoach.com>