### PR TITLE
Fix #79 : Build create an useless eclipsec.exe file

### DIFF
--- a/fr.cnes.icode.repository/p2.inf
+++ b/fr.cnes.icode.repository/p2.inf
@@ -1,0 +1,1 @@
+instructions.configure=org.eclipse.equinox.p2.touchpoint.natives.remove(path:${installFolder}/eclipsec.exe);


### PR DESCRIPTION
Just add the p2.inf file to remove the unexpected file. 

Signed-off-by: Olivier Prouvost <olivier.prouvost@opcoach.com>