### PR TITLE
JFlexException improvement and lexer's lists verification

### DIFF
--- a/fr.cnes.analysis.tools.analyzer/src/fr/cnes/analysis/tools/analyzer/Analyzer.java
+++ b/fr.cnes.analysis.tools.analyzer/src/fr/cnes/analysis/tools/analyzer/Analyzer.java
@@ -132,16 +132,19 @@ public class Analyzer {
                             Runtime.getRuntime().gc();
                         }
                         analyzers.add(service.submit(callableAnalysis));
-
                     }
                 }
             }
             for (Future<List<CheckResult>> analysis : analyzers) {
                 analysisResultCheckResult.addAll(analysis.get());
             }
-        } catch (NullContributionException | ExecutionException | InterruptedException
-                        | CoreException e) {
+        } catch (NullContributionException | InterruptedException | CoreException e) {
+
             LOGGER.throwing(this.getClass().getName(), methodName, e);
+        } catch (ExecutionException exception) {
+            if (exception.getCause() instanceof JFlexException) {
+                throw (JFlexException) exception.getCause();
+            }
         }
         return analysisResultCheckResult;
     }

--- a/fr.cnes.analysis.tools.analyzer/src/fr/cnes/analysis/tools/analyzer/datas/AbstractChecker.java
+++ b/fr.cnes.analysis.tools.analyzer/src/fr/cnes/analysis/tools/analyzer/datas/AbstractChecker.java
@@ -169,4 +169,17 @@ public abstract class AbstractChecker {
         return inputFile;
     }
 
+    /**
+     * @param str
+     *            to set to ASCII decimal
+     * @return
+     * @return ASCII decimal of <code>str</code>
+     */
+    public static final String toASCII(final String str) {
+        String code = "";
+        for (char character : str.toCharArray()) {
+            code += (int) character;
+        }
+        return code;
+    }
 }

--- a/fr.cnes.analysis.tools.analyzer/src/fr/cnes/analysis/tools/analyzer/exception/JFlexException.java
+++ b/fr.cnes.analysis.tools.analyzer/src/fr/cnes/analysis/tools/analyzer/exception/JFlexException.java
@@ -77,9 +77,9 @@ public class JFlexException extends Exception {
      */
     private static String errorMessage(String pRuleName, String pFileName, String pMessage,
                     String pLastScan, int pLine, int pColumn) {
-        final String message = "i-Code CNES Exception during analysis.\n" + "CheckerId : "
-                        + pRuleName + "\n" + "File : " + pFileName + "\n" + "ErrorMessage : "
-                        + pMessage + "\n" + "Line:" + pLine + "\n" + "Column:" + pColumn + "\n"
+        final String message = "i-Code CNES analysis encountered a problem.\n\n" + pMessage + "\n"
+                        + "CheckerId : " + pRuleName + "\n" + "File : " + pFileName + "\n" + "Line:"
+                        + pLine + "\n" + "Column:" + pColumn + "\n"
 
                         + "Last word scanned :" + pLastScan + "\n"
                         + "You can report this issue on : https://github.com/dupuisa/i-CodeCNES/issues/";
@@ -127,7 +127,7 @@ public class JFlexException extends Exception {
     /**
      * @return the message
      */
-    public final String getMessage() {
+    public final String getErrorMessage() {
         return message;
     }
 

--- a/fr.cnes.analysis.tools.fortran77.metrics/lex/ExampleMetric.lex
+++ b/fr.cnes.analysis.tools.fortran77.metrics/lex/ExampleMetric.lex
@@ -39,6 +39,7 @@ import fr.cnes.analysis.tools.analyzer.metrics.FunctionMetricValue;
 %class GeneratedMetricName
 %extends AbstractChecker
 %public
+%column
 %line
 
 /* This three lines are not meant to be modified. */
@@ -84,6 +85,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /* in this section.																*/
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	FileMetricValue fileValue;
 	
 	public GeneratedMetricName(){

--- a/fr.cnes.analysis.tools.fortran77.metrics/lex/F77METComplexitySimplified.lex
+++ b/fr.cnes.analysis.tools.fortran77.metrics/lex/F77METComplexitySimplified.lex
@@ -37,8 +37,9 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %extends AbstractChecker
 %public
 %ignorecase
-%line
 %column
+%line
+
 
 %function run
 %yylexthrow JFlexException
@@ -77,10 +78,11 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
     
 
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	float numCiclomatic = 0;
 	float numCiclomaticTotal = 0;
 	int functionLine = 0;
-	String parsedFileName;
+	
 	
 	public F77METComplexitySimplified() {
 	
@@ -90,7 +92,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	public void setInputFile(File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         this.parsedFileName = file.toString();
         LOGGER.finest("end method setInputFile");       
 	}
@@ -228,6 +231,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 
 
 				[^]            {
-                                   String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+yyline+" column:"+yycolumn;
-				                   throw new JFlexException(new Exception(errorMessage));
-				                }
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran77.metrics/lex/F77METLineOfCode.lex
+++ b/fr.cnes.analysis.tools.fortran77.metrics/lex/F77METLineOfCode.lex
@@ -35,8 +35,9 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %extends AbstractChecker
 %public
 %ignorecase
-%line
 %column
+%line
+
 
 %function run
 %yylexthrow JFlexException
@@ -66,10 +67,11 @@ SPACE		 = [\ \r\f\t]
     private static final Logger LOGGER = Logger.getLogger(F77METLineOfCode.class.getName());
     
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	float numLines = 0;
 	float numTotal = 0;
 	int functionLine = 0;
-    String parsedFileName;
+    
 	
 	
 	public F77METLineOfCode(){
@@ -79,7 +81,8 @@ SPACE		 = [\ \r\f\t]
 	public void setInputFile(File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         this.parsedFileName = file.toString();
         LOGGER.finest("end method setInputFile");       
 	}
@@ -260,6 +263,8 @@ SPACE		 = [\ \r\f\t]
 /* DEFAULT STATE 	*/
 /********************/
 				[^]            {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+yyline+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
-                               }
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran77.metrics/lex/F77METNesting.lex
+++ b/fr.cnes.analysis.tools.fortran77.metrics/lex/F77METNesting.lex
@@ -36,8 +36,9 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %extends AbstractChecker
 %public
 %ignorecase
-%line
 %column
+%line
+
 
 %function run
 %yylexthrow JFlexException
@@ -73,13 +74,14 @@ SMBL		 = \&   	  | \+			| \$
     
 
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	List<String> identifiers = new LinkedList<String>();
 	float numImbrics = 0;
 	float numMaxImbrics = 0;
 	float numImbricsTotal = 0;
 	boolean end = true;
 	int functionLine = 0;
-	String parsedFileName;
+	
 	
 	public F77METNesting(){ 
 	}
@@ -88,7 +90,8 @@ SMBL		 = \&   	  | \+			| \$
 	public void setInputFile(File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         this.parsedFileName = file.toString();
         LOGGER.finest("end method setInputFile");       
 	}
@@ -260,6 +263,8 @@ SMBL		 = \&   	  | \+			| \$
 
 
 				[^]            {
-				                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+yyline+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
-                               }
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran77.metrics/lex/F77METRatioComment.lex
+++ b/fr.cnes.analysis.tools.fortran77.metrics/lex/F77METRatioComment.lex
@@ -33,8 +33,9 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %extends AbstractChecker
 %public
 %ignorecase
-%line
 %column
+%line
+
 
 %function run
 %yylexthrow JFlexException
@@ -60,11 +61,12 @@ END			 = END		  | end
 	
 	
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	Float numLines = 0.0f;
 	Float numComments = 0.0f;
 	boolean endLine = true;
 	int functionLine = 0;
-    String parsedFileName;
+    
 	
 	
 	public F77METRatioComment() {
@@ -74,7 +76,8 @@ END			 = END		  | end
 	public void setInputFile(File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         this.parsedFileName = file.toString();
         LOGGER.finest("end method setInputFile");       
 	}
@@ -299,7 +302,9 @@ END			 = END		  | end
 /*********************/
 /*	ERROR THROWN	 */
 /*********************/	
-			[^]      	{
-            			        String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+yyline+" column:"+yycolumn;
-                                throw new JFlexException(new Exception(errorMessage));
-            			}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMDATAFloatCompare.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMDATAFloatCompare.lex
@@ -96,8 +96,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
-        this.parsedFileName = file.toString();
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+        
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
 	}
 	
@@ -520,6 +521,8 @@ FUNCTION	 = {VAR}{SPACE}*"("
 /*	ERROR THROWN	 */
 /*********************/			
 			[^]      	{
-                                    String errorMessage = "Class"+this.getClass().getName()+" \nIllegal character <" + yytext() + "> \nFile :"+ this.parsedFileName+" \nat line:"+yyline+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
-                        }
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+				        }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMDATAInitialisation.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMDATAInitialisation.lex
@@ -144,8 +144,9 @@ SEE_FUNC	 = ([^a-zA-Z0-9\_])?("if" | "elseif" | "forall" | "while" | "where" | "
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
-        this.parsedFileName = file.toString();
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+        
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
 	}
 	
@@ -766,6 +767,8 @@ return getCheckResults();
 /* ERROR STATE	        */
 /************************/
 				[^]            {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+yyline+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
-                                }
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                               }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMDATAInvariant.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMDATAInvariant.lex
@@ -82,8 +82,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
-        this.parsedFileName = file.toString();
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+        
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
 	}
 	
@@ -326,6 +327,8 @@ return getCheckResults();
 /* ERROR STATE	        */
 /************************/
 				[^]            {
-				                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+yyline+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+				                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                 }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMDATALoopCondition.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMDATALoopCondition.lex
@@ -91,8 +91,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
-        this.parsedFileName = file.toString();
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+        
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
 	}
 	
@@ -408,6 +409,8 @@ WHILE	  = "while"
 <LINE>      	.              	{}
 
 				[^]            {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                 }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMDATANotUsed.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMDATANotUsed.lex
@@ -80,8 +80,9 @@ EQUAL		 = \= [^\,\n\"\']*
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
-        this.parsedFileName = file.toString();
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+        
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
 	}
 	
@@ -271,6 +272,8 @@ return getCheckResults();
 /* ERROR STATE	        */
 /************************/
 				[^]            {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                 }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMDESIGNActiveWait.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMDESIGNActiveWait.lex
@@ -72,8 +72,9 @@ WAIT		 = "sleep" 	| "wait"	| "pause"
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
-        this.parsedFileName = file.toString();
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+        
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
 	}
 	
@@ -220,6 +221,8 @@ WAIT		 = "sleep" 	| "wait"	| "pause"
 /* ERROR STATE	        */
 /************************/
 				[^]            {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                 }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMDESIGNAlloc.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMDESIGNAlloc.lex
@@ -83,8 +83,9 @@ INT			 = [0-9]+
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
-        this.parsedFileName = file.toString();
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+        
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
 	}
 	
@@ -383,6 +384,8 @@ INT			 = [0-9]+
 /* ERROR STATE	        */
 /************************/
 				[^]            {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                 }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMFLOWAbort.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMFLOWAbort.lex
@@ -69,6 +69,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
@@ -183,6 +184,8 @@ return getCheckResults();
 /* ERROR STATE	        */
 /************************/
 				[^]            {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                 }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMFLOWBooleanExpression.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMFLOWBooleanExpression.lex
@@ -77,6 +77,7 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
@@ -201,6 +202,8 @@ return getCheckResults();
 /* ERROR STATE	        */
 /************************/
 				[^]           {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                 }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMFLOWCheckCodeReturn.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMFLOWCheckCodeReturn.lex
@@ -148,6 +148,7 @@ AVOIDED		 = {SPACE}*( "abs" | "achar" | "acos" | "acosh" | "adjustl" | "adjustr"
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 		codeLevel.add(1);
@@ -566,6 +567,8 @@ return getCheckResults();
 /* ERROR STATE	        */
 /************************/
 				[^]            	{
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                 }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMFLOWCheckUser.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMFLOWCheckUser.lex
@@ -70,8 +70,9 @@ GETUID		 = "GETUID"{SPACE}*\({SPACE}*\)
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
-        this.parsedFileName = file.toString();
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+        
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
 	}
 	
@@ -222,6 +223,8 @@ GETUID		 = "GETUID"{SPACE}*\({SPACE}*\)
 /* ERROR STATE	        */
 /************************/
 				[^]            {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                 }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMFLOWExit.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMFLOWExit.lex
@@ -75,6 +75,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
@@ -205,6 +206,8 @@ return getCheckResults();
 /* ERROR STATE	        */
 /************************/
 				[^]            {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                 }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMFLOWExitLoop.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMFLOWExitLoop.lex
@@ -81,6 +81,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
@@ -225,6 +226,7 @@ END       = [^a-zA-Z0-9\_]("end")[^a-zA-Z0-9\_]{SPACE}*({IF} | {SELECT} | {DO} |
 /*	ERROR THROWN	 */
 /*********************/
 			[^]			{
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
-                        }
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);                        }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMFLOWFileExistence.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMFLOWFileExistence.lex
@@ -84,6 +84,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
@@ -267,6 +268,8 @@ return getCheckResults();
 /* ERROR STATE	        */
 /************************/
 				[^]           {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
-                                }
+                          			String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                              }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMFLOWFilePath.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMFLOWFilePath.lex
@@ -72,6 +72,7 @@ FILENAME	 = \'[\.]*[a-zA-Z\/][a-zA-Z0-9\_\/]*(\.[a-zA-Z0-9]+)?\'  |
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
@@ -203,6 +204,8 @@ return getCheckResults();
 /* ERROR STATE	        */
 /************************/
 				[^]            {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                 }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMINSTBoolNegation.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMINSTBoolNegation.lex
@@ -72,6 +72,7 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
@@ -215,6 +216,8 @@ return getCheckResults();
 /* ERROR STATE	        */
 /************************/
 				[^]           {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMINSTBrace.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMINSTBrace.lex
@@ -82,6 +82,7 @@ SPACE		 = [\ \r\t\f]
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
@@ -379,6 +380,8 @@ SPACE		 = [\ \r\t\f]
 /* ERROR STATE	        */
 /************************/
 				[^]            {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                 }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMINSTCodeComment.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMINSTCodeComment.lex
@@ -130,6 +130,7 @@ SPACE		 = [\ \r\t\f]
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
@@ -331,6 +332,8 @@ return getCheckResults();
 /* ERROR STATE	        */
 /************************/
 				[^]            {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMINSTGoTo.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMINSTGoTo.lex
@@ -69,6 +69,7 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
@@ -166,6 +167,8 @@ return getCheckResults();
 /* ERROR STATE	        */
 /************************/
 				[^]            {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMINSTLoopCondition.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMINSTLoopCondition.lex
@@ -73,6 +73,7 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
@@ -190,6 +191,8 @@ return getCheckResults();
 /* ERROR STATE	        */
 /************************/
 				[^]           {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMNAMEHomonymy.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMNAMEHomonymy.lex
@@ -88,6 +88,7 @@ SPACE		 = [\ \r\t\f]
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
@@ -361,6 +362,8 @@ return getCheckResults();
 /* ERROR STATE	        */
 /************************/
 				[^]            {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMPRESIndent.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMPRESIndent.lex
@@ -96,6 +96,7 @@ SIMBOL		 = \& 		  | \$ 		   | \+			| [A-Za-z][\ ]	| \.	| [0-9]
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
@@ -497,6 +498,8 @@ return getCheckResults();
 /* ERROR STATE	        */
 /************************/
 				[^]            {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMPRESLengthLine.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMPRESLengthLine.lex
@@ -67,6 +67,7 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
@@ -197,6 +198,8 @@ return getCheckResults();
 /* ERROR STATE	        */
 /************************/
 				[^]            {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMPROJECTHeader.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMPROJECTHeader.lex
@@ -80,6 +80,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
@@ -272,6 +273,8 @@ SPACE = [\ \f\t]+
 /* ERROR STATE	        */
 /************************/
 				[^]            {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/COMTYPEExpression.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/COMTYPEExpression.lex
@@ -113,6 +113,7 @@ SIMBOL		 = \& 		  | \$ 		   | \+			| [A-Za-z][\ ]	| \.	| [0-9]	| \*
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
@@ -386,6 +387,8 @@ SIMBOL		 = \& 		  | \$ 		   | \+			| [A-Za-z][\ ]	| \.	| [0-9]	| \*
 /* ERROR STATE	        */
 /************************/
 				[^]            {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77BLOCCommon.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77BLOCCommon.lex
@@ -67,6 +67,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
@@ -184,6 +185,8 @@ RULE_WORD = {COMMON}([^\/\n]*)([\n])
 /*	ERROR THROWN	 */
 /*********************/
 				[^]           {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77BLOCElse.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77BLOCElse.lex
@@ -74,6 +74,7 @@ INT			 = [0-9]+
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
@@ -283,6 +284,8 @@ CONT	  = CONTINUE| continue
 /*	ERROR THROWN	 */
 /*********************/
 				[^]            {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77BLOCFunction.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77BLOCFunction.lex
@@ -78,6 +78,7 @@ EQUAL		 = \=
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
@@ -223,6 +224,8 @@ return getCheckResults();
 								 yybegin(COMMENT);}
 
 				[^]           {
-                                    String errorMessage = "Class"+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.parsedFileName+"\nat line:"+(yyline+1)+" column:"+yycolumn;
-                                    throw new JFlexException(new Exception(errorMessage));
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
                                }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77BLOCLoop.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77BLOCLoop.lex
@@ -69,6 +69,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.finest("begin method setInputFile");
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.finest("end method setInputFile");
@@ -201,4 +202,9 @@ INT		  = [0-9]+
 									yybegin(NEW_LINE);}
 <LINE>      	.              	{}
 
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77DATAArray.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77DATAArray.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F77DATAArray
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -69,6 +70,8 @@ SMB 		 = \& 		  | \$ 		   | \+			| [A-Za-z][\ ]	| \.	| [0-9]
 	String variable = "";
 	/** boolean to know if the comment line exist **/
 	boolean comment = false; 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	public F77DATAArray() {
     }
@@ -76,7 +79,9 @@ SMB 		 = \& 		  | \$ 		   | \+			| [A-Za-z][\ ]	| \.	| [0-9]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -158,4 +163,9 @@ SMB 		 = \& 		  | \$ 		   | \+			| [A-Za-z][\ ]	| \.	| [0-9]
 <PARS>			.				{}	
 
 
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77DATACommon.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77DATACommon.lex
@@ -33,6 +33,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F77DATACommon
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -74,7 +75,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
 		LOGGER.finest("begin method setInputFile");
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 		LOGGER.finest("end method setInputFile");
 	}
 	
@@ -201,4 +203,11 @@ return getCheckResults();
 								}
 <INCLUDE>		.				{}
 
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+
+								String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }
+								

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77DATADouble.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77DATADouble.lex
@@ -32,6 +32,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %extends AbstractChecker
 %public
 %line
+%column
 %ignorecase
 
 %function run
@@ -70,7 +71,9 @@ SIMBOL		 = \& 		  | \$ 		   | \+			| [A-Za-z][\ ]	| \.	| [0-9]		| \~
 	/** Current variabe to analize **/
 	String variable = "";
 	/** Evluation boolean to detect if an error can be thrown or not **/
-	boolean eval = false;
+	boolean eval = false; 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	public F77DATADouble() {
     }
@@ -78,7 +81,8 @@ SIMBOL		 = \& 		  | \$ 		   | \+			| [A-Za-z][\ ]	| \.	| [0-9]		| \~
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	/** If the var found is a double precision, check is there is a number after that
@@ -158,4 +162,9 @@ SIMBOL		 = \& 		  | \$ 		   | \+			| [A-Za-z][\ ]	| \.	| [0-9]		| \~
 <NUMBER>		\n				{eval = false; yybegin(NEW_LINE);}
 <NUMBER>		.				{eval = false; yybegin(LINE);}
 
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+								String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77DATAIO.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77DATAIO.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F77DATAIO
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -56,7 +57,9 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 %{
 	String location = "MAIN PROGRAM";
 	
-	String io;
+	String io; 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	public F77DATAIO() {
     }
@@ -64,7 +67,8 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 %}
 
@@ -111,4 +115,9 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 <IO_STATE>		\n				{yybegin(NEW_LINE);}
 <IO_STATE>		.				{}
 
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77DATAInitialisation.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77DATAInitialisation.lex
@@ -32,6 +32,8 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %extends AbstractChecker
 %public
 %line
+%column
+
 
 %function run
 %yylexthrow JFlexException
@@ -58,7 +60,9 @@ SIMBOL		 = \& 		  | \$ 		   | \+			| [A-Za-z][\ ]	| \.	| [0-9]
 %{
 	String location = "MAIN PROGRAM";
 	
-	List<String> identifiers = new LinkedList<String>();
+	List<String> identifiers = new LinkedList<String>(); 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	public F77DATAInitialisation() {
     }
@@ -66,7 +70,8 @@ SIMBOL		 = \& 		  | \$ 		   | \+			| [A-Za-z][\ ]	| \.	| [0-9]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 %}
 
@@ -130,4 +135,9 @@ SIMBOL		 = \& 		  | \$ 		   | \+			| [A-Za-z][\ ]	| \.	| [0-9]
 <INIT>			\n				{yybegin(NEW_LINE);}
 <INIT>			.				{}
 
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77DATALoopDO.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77DATALoopDO.lex
@@ -60,7 +60,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 SPACE		 = [\ \t\r]
 
 %{
-	String location = "MAIN PROGRAM";
+	String location = "MAIN PROGRAM"; 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	
 	public F77DATALoopDO() {
@@ -69,7 +71,8 @@ SPACE		 = [\ \t\r]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 %}
 
@@ -211,4 +214,9 @@ WRONG_TYPE  = {REAL} 			| {DOUBLE_PREC} | {COMPLEX} | {LOGICAL} | {CHAR}
 /*********************/
 /*	ERROR THROWN	 */
 /*********************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77DATAParameter.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77DATAParameter.lex
@@ -32,6 +32,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %extends AbstractChecker
 %public
 %line
+%column
 %ignorecase
 
 %function run
@@ -75,7 +76,9 @@ SIMBOL		 = \& 		  | \$ 		   | \+			| [A-Za-z][\ ]	| \.	| [0-9]	| \*
 	int par = 0;
 	/** Paramters to throw error **/
 	String errors = "";
-	boolean first = true;
+	boolean first = true; 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	
 	public F77DATAParameter() {
@@ -84,7 +87,8 @@ SIMBOL		 = \& 		  | \$ 		   | \+			| [A-Za-z][\ ]	| \.	| [0-9]	| \*
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	private void checkFucntionParameter(String param) throws JFlexException {
@@ -172,4 +176,9 @@ return getCheckResults();
 <PAR>			\)				{par--; if(par==0) yybegin(PARAMETERS); }
 <PAR>			[^]			{}
 
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77ERROpenRead.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77ERROpenRead.lex
@@ -34,6 +34,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F77ERROpenRead
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -81,7 +82,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	String location = "MAIN PROGRAM"; 
  
 	boolean found = false;
-	boolean multLines = false;
+	boolean multLines = false; 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	public F77ERROpenRead() {
     }
@@ -89,7 +92,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 %}
@@ -170,4 +174,9 @@ return getCheckResults();
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]           {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]           {
+							  		String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+							  }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77INSTAssign.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77INSTAssign.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F77INSTAssign
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -50,7 +51,9 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 STRING		 = \'[^\']*\' | \"[^\"]*\"
 
 %{
-	String location = "MAIN PROGRAM";
+	String location = "MAIN PROGRAM"; 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	
 	public F77INSTAssign() {
@@ -59,7 +62,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 %}
 
@@ -129,4 +133,9 @@ RULE_WORD = assign | ASSIGN
 /*********************/
 /*	ERROR THROWN	 */
 /*********************/
-				[^]           {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]           {
+							  		String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+							  }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77INSTDimension.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77INSTDimension.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F77INSTDimension
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -50,7 +51,9 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 STRING		 = \'[^\']*\' | \"[^\"]*\"
 
 %{
-	String location = "MAIN PROGRAM";
+	String location = "MAIN PROGRAM"; 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	
 	public F77INSTDimension() {
@@ -59,7 +62,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 %}
 
@@ -128,4 +132,9 @@ RULE_WORD = dimension | DIMENSION
 /*********************/
 /*	ERROR THROWN	 */
 /*********************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77INSTEquivalence.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77INSTEquivalence.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F77INSTEquivalence
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -51,6 +52,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 
 %{
 	String location = "MAIN PROGRAM";
+	 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	
 	public F77INSTEquivalence() {
@@ -59,7 +63,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 %}
 
@@ -126,4 +131,9 @@ RULE_WORD = equivalence | EQUIVALENCE
 <LINE>      	\n             	{yybegin(NEW_LINE);}
 <LINE>      	.              	{}
 
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77INSTFunction.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77INSTFunction.lex
@@ -57,6 +57,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	String location = "MAIN PROGRAM";
 	
 	Boolean explicitDeclaration = false;
+	 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	public F77INSTFunction() {
     }
@@ -64,7 +67,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 %}
 
@@ -117,4 +121,10 @@ return getCheckResults();
 <LINE>      	\n             	{explicitDeclaration=false; yybegin(NEW_LINE);}
 <LINE>      	.              	{}
 
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+							   		String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+							   }
+							   

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77INSTIf.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77INSTIf.lex
@@ -57,7 +57,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 INT			 = [0-9]+
 
 %{
-	String location = "MAIN PROGRAM";
+	String location = "MAIN PROGRAM"; 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	int bracket = 0;
 	
@@ -67,7 +69,8 @@ INT			 = [0-9]+
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 %}
 
@@ -163,4 +166,9 @@ CONT	  = CONTINUE  | continue
 /*********************/
 /*	ERROR THROWN	 */
 /*********************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77INSTInclude.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77INSTInclude.lex
@@ -74,7 +74,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	boolean include = false;
 	private String fileName ;
 	private File includeFile;
-	private String project;
+	private String project; 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	public F77INSTInclude() {
 		this.include = false;
@@ -89,7 +91,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
 		project = getProjectPath(new Path(file.getAbsolutePath()).toOSString());
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	private void analyseFile(String fileN) throws JFlexException {
@@ -210,4 +213,9 @@ return getCheckResults();
 /*********************/
 /*	ERROR THROWN	 */
 /*********************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77INSTPause.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77INSTPause.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F77INSTPause
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -50,7 +51,9 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 STRING		 = \'[^\']*\' | \"[^\"]*\"
 
 %{
-	String location = "MAIN PROGRAM";
+	String location = "MAIN PROGRAM"; 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	
 	public F77INSTPause() {
@@ -59,7 +62,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 %}
 
@@ -125,4 +129,9 @@ RULE_WORD = pause | PAUSE
 /*********************/
 /*	ERROR THROWN	 */
 /*********************/
-				[^]           {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]           {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77INSTReturn.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77INSTReturn.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F77INSTReturn
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -53,7 +54,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /* A boolean to determine if RETURN has been found once is set. */
 /* A last boolean is to determine if it is a RETURN (i) word.	*/
 %{
-	String location = "MAIN PROGRAM";
+	String location = "MAIN PROGRAM"; 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	public F77INSTReturn() {
     }
@@ -61,7 +64,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 %}
 
@@ -124,4 +128,9 @@ RULE_WORD = return | RETURN
 /*********************/
 /*	ERROR THROWN	 */
 /*********************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77INSTSave.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77INSTSave.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F77INSTSave
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -57,7 +58,9 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
  
 																
 %{
-	String location = "MAIN PROGRAM";
+	String location = "MAIN PROGRAM"; 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	boolean comment = false;
 	
@@ -67,7 +70,8 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 
 	private void checkSave() throws JFlexException{
@@ -116,4 +120,9 @@ return getCheckResults();
 <LINE>      	.              	{}
 		
 
-				[^]           {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]           {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77METLine.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77METLine.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class F77METLine
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -50,7 +51,9 @@ TYPE		 = {FUNC}     | {PROC}	   | {SUB} | {PROG} | {MOD}
 VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 																
 %{
-	String location = "MAIN PROGRAM";
+	String location = "MAIN PROGRAM"; 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	int lineChars = 0;
 	boolean showError = false;
@@ -61,7 +64,8 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 
 	
@@ -114,4 +118,9 @@ return getCheckResults();
 								 }
 								}
 
-				[^]           {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]           {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77NAMEGenericIntrinsic.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77NAMEGenericIntrinsic.lex
@@ -33,6 +33,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %extends AbstractChecker
 %public
 %line
+%column
 %ignorecase
 
 %function run
@@ -61,7 +62,9 @@ SIMBOL		 = \& 		  | \$ 		   | \+			| [A-Za-z][\ ]	| \.	| [0-9]
 	
 	List<String> intrinseques =  new LinkedList<String>();
 	List<String> intrinsequesGeneriques =  new LinkedList<String>();
-	List<String> variables = new LinkedList<String>();
+	List<String> variables = new LinkedList<String>(); 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	public F77NAMEGenericIntrinsic() {
 		List<String> intr = Arrays.asList("IFIX","IDINT","FLOAT","SNGL","ICHAR","CHAR","DINT","DNINT","IDNINT","IABS","DABS","CABS","AMOD","DMOD","ISIGN","DSIGN","IDIM","DDIM","DPROD","MAX0","AMAX1","DMAX1","AMAX0","MAX1","MIN0","AMIN1","DMIN1","AMIN0","MIN1","DSQRT","CSQRT","DEXP","CEXP","ALOG","DLOG","CLOG","ALOG10","DLOG10","DSIN","CSIN","DCOS","CCOS","DTAN","DASIN","DACOS","DATAN","DATAN2","DSINH","DCOSH","DTANH");
@@ -73,7 +76,8 @@ SIMBOL		 = \& 		  | \$ 		   | \+			| [A-Za-z][\ ]	| \.	| [0-9]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 
 	private void checkFunctionName(String text) throws JFlexException {
@@ -129,4 +133,9 @@ SIMBOL		 = \& 		  | \$ 		   | \+			| [A-Za-z][\ ]	| \.	| [0-9]
 <DECLARATION>  	\n             	{yybegin(NEW_LINE);}
 <DECLARATION>  	.              	{}
 
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);	
+								}

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77NAMEIntrinsic.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77NAMEIntrinsic.lex
@@ -37,6 +37,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class F77NAMEIntrinsic
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -59,7 +60,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 %{
 	String location = "MAIN PROGRAM";
 	
-	List<String> intrinseques =  new LinkedList<String>();
+	List<String> intrinseques =  new LinkedList<String>(); 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	public F77NAMEIntrinsic() {
 		//readFile();
@@ -70,7 +73,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 
 	private void checkFunctionName(String text) throws JFlexException {
@@ -147,4 +151,9 @@ return getCheckResults();
 <FUNCTION>		\n				{yybegin(NEW_LINE);}
 <FUNCTION>		.				{}
 
-				[^]           {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]           {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77NAMEKeyWords.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77NAMEKeyWords.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F77NAMEKeyWords
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -64,7 +65,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 SPACE		 = [\ \t\r]
 																
 %{
-	String location = "MAIN PROGRAM";
+	String location = "MAIN PROGRAM"; 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	
 	public F77NAMEKeyWords() {
@@ -73,7 +76,8 @@ SPACE		 = [\ \t\r]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 %}
 
@@ -124,5 +128,9 @@ SPACE		 = [\ \t\r]
 /*********************/
 /*	ERROR THROWN	 */
 /*********************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
-
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77NAMELabel.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77NAMELabel.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F77NAMELabel
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -55,7 +56,9 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 STRING		 = \'[^\']*\' | \"[^\"]*\"
 																
 %{
-	String location = "MAIN PROGRAM";
+	String location = "MAIN PROGRAM"; 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	
 	public F77NAMELabel() {
@@ -64,7 +67,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 %}
 
@@ -108,5 +112,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /*********************/
 /*	ERROR THROWN	 */
 /*********************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
-
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+				               }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77PROTODeclaration.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77PROTODeclaration.lex
@@ -33,6 +33,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %extends AbstractChecker
 %public
 %line
+%column
 %ignorecase
 
 %function run
@@ -74,7 +75,9 @@ SIMBOL		 = \& 		  | \$ 		   | \+			| [A-Za-z][\ ]	| \.	| \*
 	/** Posible list of error locatin **/
 	List<String> errorLocation     		= new LinkedList<String>();
 	/** Posible list of error lines **/
-	List<Integer> errorLine		   		= new LinkedList<Integer>();
+	List<Integer> errorLine		   		= new LinkedList<Integer>(); 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	
 	public F77PROTODeclaration() {
@@ -89,7 +92,8 @@ SIMBOL		 = \& 		  | \$ 		   | \+			| [A-Za-z][\ ]	| \.	| \*
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	/** For each value of call functions see if the is a true error. An error is when the function called is
@@ -187,5 +191,9 @@ SIMBOL		 = \& 		  | \$ 		   | \+			| [A-Za-z][\ ]	| \.	| \*
 /*********************/
 /*	ERROR THROWN	 */
 /*********************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
-
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+				               }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77REFOpen.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77REFOpen.lex
@@ -34,6 +34,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F77REFOpen
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -66,7 +67,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	boolean statusFound = false;
 	boolean unknownFound = false;
 	boolean positionFound = false;
-	boolean multLines = false;
+	boolean multLines = false; 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	public F77REFOpen() {
     }
@@ -74,7 +77,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	public void checkViolation(final boolean fileFound, final boolean scratchFound, final boolean statusFound, final boolean unknownFound, final boolean positionFound) throws JFlexException {
@@ -151,4 +155,9 @@ POSITION  = position | POSITION
 <LINE>      	\n             	{yybegin(NEW_LINE);}
 <LINE>      	.              	{}
 
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+				               }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77REFParameter.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77REFParameter.lex
@@ -32,6 +32,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %extends AbstractChecker
 %public
 %line
+%column
 
 %function run
 %yylexthrow JFlexException
@@ -57,7 +58,9 @@ PARAM		 = [^\,\)\n\ ]
 %{
 	String location = "MAIN PROGRAM";
 	
-	List<String> commonList = new LinkedList<String>();
+	List<String> commonList = new LinkedList<String>(); 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	public F77REFParameter() {
     }
@@ -65,7 +68,8 @@ PARAM		 = [^\,\)\n\ ]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 
@@ -129,4 +133,9 @@ PARAM		 = [^\,\)\n\ ]
 <FNC_PARS>		.				{}
 
 
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+				               }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77TYPEBasic.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77TYPEBasic.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %extends AbstractChecker
 %public
 %line
+%column
 
 %function run
 %yylexthrow JFlexException
@@ -56,7 +57,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 SPACE		 = [\ \t\r]
 																
 %{
-	String location = "MAIN PROGRAM";
+	String location = "MAIN PROGRAM"; 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	
 	public F77TYPEBasic() {
@@ -65,7 +68,8 @@ SPACE		 = [\ \t\r]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 
@@ -109,4 +113,9 @@ SPACE		 = [\ \t\r]
 <LINE>      	\n             		{yybegin(NEW_LINE);}
 <LINE>      	.              		{}
 
-				[^]            	{throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            	{
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+				               }

--- a/fr.cnes.analysis.tools.fortran77.rules/lex/F77TYPEHollerith.lex
+++ b/fr.cnes.analysis.tools.fortran77.rules/lex/F77TYPEHollerith.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %extends AbstractChecker
 %public
 %line
+%column
 
 %function run
 %yylexthrow JFlexException
@@ -50,7 +51,9 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 STRING		 = \'[^\']*\' | \"[^\"]*\"
 
 %{
-	String location = "MAIN PROGRAM";
+	String location = "MAIN PROGRAM"; 
+	/** name of the file parsed */
+	private String parsedFileName;
 	
 	
 	public F77TYPEHollerith() {
@@ -59,7 +62,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 %}
 
@@ -130,4 +134,9 @@ RULE_WORD = [1-9]+[0-9]*[h|H][a-zA-Z\ \t]+
 /*********************/
 /*	ERROR THROWN	 */
 /*********************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+				               }

--- a/fr.cnes.analysis.tools.fortran90.metrics/lex/F90METComplexitySimplified.lex
+++ b/fr.cnes.analysis.tools.fortran90.metrics/lex/F90METComplexitySimplified.lex
@@ -35,8 +35,9 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %extends AbstractChecker
 %public
 %ignorecase
-%line
 %column
+%line
+
 
 %function run
 %yylexthrow JFlexException
@@ -78,6 +79,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
  */
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	float numCiclomatic = 0;
 	float numCiclomaticTotal = 0;
 	int functionLine = 0;
@@ -88,7 +90,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	private void endLocation() throws JFlexException {
@@ -157,4 +160,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 <LINE>      	.              	{}
 
 
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran90.metrics/lex/F90METLineOfCode.lex
+++ b/fr.cnes.analysis.tools.fortran90.metrics/lex/F90METLineOfCode.lex
@@ -35,8 +35,9 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %extends AbstractChecker
 %public
 %ignorecase
-%line
 %column
+%line
+
 
 %function run
 %yylexthrow JFlexException
@@ -62,6 +63,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /* comment's rate on each section (function, procedure, etc.).			*/
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	float numLines = 1;
 	float numTotal = 1;
 	int functionLine = 0;
@@ -72,7 +74,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	private void endLocation() throws JFlexException {
 		final List<CheckResult> list = this.getCheckResults();
@@ -151,4 +154,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 <LINE>      	.              	{}
 
 
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran90.metrics/lex/F90METNesting.lex
+++ b/fr.cnes.analysis.tools.fortran90.metrics/lex/F90METNesting.lex
@@ -37,8 +37,9 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %extends AbstractChecker
 %public
 %ignorecase
-%line
 %column
+%line
+
 
 %function run
 %yylexthrow JFlexException
@@ -70,6 +71,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	List<String> identifiers = new LinkedList<String>();
 	float numImbrics = 0;
 	float numMaxImbrics = 0;
@@ -83,7 +85,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	private void addImbrics() {
@@ -191,4 +194,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + "> at line :"+yyline) );}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran90.metrics/lex/F90METRatioComment.lex
+++ b/fr.cnes.analysis.tools.fortran90.metrics/lex/F90METRatioComment.lex
@@ -35,8 +35,9 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %extends AbstractChecker
 %public
 %ignorecase
-%line
 %column
+%line
+
 
 %function run
 %yylexthrow JFlexException
@@ -58,6 +59,7 @@ END			 = END		  | end
 
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	Float numLines = 0.0f;
 	Float numComments = 0.0f;
 	int functionLine = 0;
@@ -69,7 +71,8 @@ END			 = END		  | end
 	@Override
 	public void setInputFile(File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	//
 	private void endLocation() throws JFlexException {
@@ -215,4 +218,9 @@ END			 = END		  | end
 /*********************/
 /*	ERROR THROWN	 */
 /*********************/	
-			[^]     	{throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMDATAFloatCompare.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMDATAFloatCompare.lex
@@ -34,6 +34,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class COMDATAFloatCompare
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -63,6 +64,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 %{
 	/** Variable used to store violation location and variable involved. **/
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	/** Variable used to store file value and function values associated. **/
 	/** This list store all variables name declared in a function, program, etc. **/
 	List<String> allVariables = new LinkedList<String>();
@@ -86,7 +88,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -385,4 +388,9 @@ DATA_TYPE	 = ("integer" | "logical" | "character" ) ( {SPACE} | {SPACE}*"(" | {S
 /*********************/
 /*	ERROR THROWN	 */
 /*********************/			
-			[^]      	{throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMDATAInitialisation.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMDATAInitialisation.lex
@@ -36,6 +36,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMDATAInitialisation
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -94,6 +95,7 @@ SEE_FUNC	 = ([^a-zA-Z0-9\_])?("if" | "elseif" | "forall" | "while" | "where" | "
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	
 	Map<String, Boolean> variables = new HashMap<String, Boolean>();
 	List<String> dimension = new LinkedList<String>();
@@ -117,8 +119,6 @@ SEE_FUNC	 = ([^a-zA-Z0-9\_])?("if" | "elseif" | "forall" | "while" | "where" | "
 	//name of sunroutine
 	String nameType="";
 	
-	/** Name of the file analyzed.*/
-	private String parsedFileName;
 
     public COMDATAInitialisation() {
     }
@@ -126,8 +126,9 @@ SEE_FUNC	 = ([^a-zA-Z0-9\_])?("if" | "elseif" | "forall" | "while" | "where" | "
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
+		
 		this.parsedFileName = file.toString();
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	//Mantis 316 EGL : detect initialized by local fonction
@@ -560,4 +561,9 @@ return getCheckResults();
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + "> at line :"+yyline) );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMDATAInvariant.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMDATAInvariant.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMDATAInvariant
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -61,6 +62,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	List<String> variables = new LinkedList<String>();
 		//mantis 322 use to keep used variables
 	List<String> usedVariables = new LinkedList<String>();
@@ -74,7 +76,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -218,4 +221,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMDATALoopCondition.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMDATALoopCondition.lex
@@ -31,8 +31,9 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class COMDATALoopCondition
 %extends AbstractChecker
 %public
-%line
 %column
+%line
+
 %ignorecase
 
 %function run
@@ -65,6 +66,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /* A String name condition is created to store the current word.				*/
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	
 	List<String> identifiers = new LinkedList<String>();
 	List<String> conditionsDo = new LinkedList<String>();
@@ -78,7 +80,6 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	boolean doVar = true;
 	String descr = "";
 	
-	private String parsedFileName;
 	
 	public COMDATALoopCondition() {
     }
@@ -86,8 +87,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
+		
 		this.parsedFileName = file.toString();
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	/** If the last identifier is:
@@ -281,4 +283,9 @@ WHILE	  = "while"
 <LINE>      	\n             	{yybegin(NEW_LINE);}
 <LINE>      	.              	{}
 
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMDATANotUsed.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMDATANotUsed.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMDATANotUsed
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -58,6 +59,7 @@ EQUAL		 = \= [^\,\n\"\']*
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	List<String> variables = new LinkedList<String>();
 	List<String> locations = new LinkedList<String>();
 	List<Integer> errors   = new LinkedList<Integer>();
@@ -69,7 +71,8 @@ EQUAL		 = \= [^\,\n\"\']*
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -191,4 +194,9 @@ EQUAL		 = \= [^\,\n\"\']*
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMDESIGNActiveWait.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMDESIGNActiveWait.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMDESIGNActiveWait
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -54,6 +55,7 @@ WAIT		 = "sleep" 	| "wait"	| "pause"
 
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	List<String> errors = new LinkedList<String>();
 	int loop = 0;
 	
@@ -63,7 +65,8 @@ WAIT		 = "sleep" 	| "wait"	| "pause"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 		
@@ -147,4 +150,9 @@ WAIT		 = "sleep" 	| "wait"	| "pause"
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMDESIGNAlloc.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMDESIGNAlloc.lex
@@ -37,6 +37,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMDESIGNAlloc
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -64,6 +65,7 @@ INT			 = [0-9]+
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	Map<String, String> memory = new HashMap<String, String>();
 	Map<String, String> files  = new HashMap<String, String>();
 	Map<String, Integer> lines = new HashMap<String, Integer>();
@@ -75,7 +77,8 @@ INT			 = [0-9]+
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	/**
@@ -280,4 +283,9 @@ INT			 = [0-9]+
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMFLOWAbort.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMFLOWAbort.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMFLOWAbort
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -54,6 +55,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	
 	public COMFLOWAbort(){
 	}
@@ -61,7 +63,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -128,4 +131,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMFLOWBooleanExpression.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMFLOWBooleanExpression.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMFLOWBooleanExpression
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -57,6 +58,7 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	int numExpr = 0;
 	int numPar = 0;
 	boolean endLine = true;
@@ -68,7 +70,8 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -149,4 +152,9 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMFLOWCaseSwitch.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMFLOWCaseSwitch.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMFLOWCaseSwitch
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -58,6 +59,7 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	Integer errorLine = 0;
 	boolean caseDefault = false;
 	
@@ -67,7 +69,8 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 %}
 
@@ -138,4 +141,9 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMFLOWCheckCodeReturn.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMFLOWCheckCodeReturn.lex
@@ -33,8 +33,9 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMFLOWCheckCodeReturn
 %extends AbstractChecker
 %public
-%line
 %column
+%line
+
 %ignorecase
 
 %function run
@@ -104,6 +105,7 @@ AVOIDED		 = {SPACE}*( "abs" | "achar" | "acos" | "acosh" | "adjustl" | "adjustr"
 %{
 	/** Variable used to store violation location and variable involved. **/
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	/** Variable used to store file value and function values associated. **/
 	/** Boolean used to determine if a line continues or not. **/
 	boolean ampFound = false;
@@ -128,7 +130,6 @@ AVOIDED		 = {SPACE}*( "abs" | "achar" | "acos" | "acosh" | "adjustl" | "adjustr"
 	/** A boolean to determine if an else statement if found. **/
 	boolean elseFound = false;
 	
-	private String parsedFileName;
 	
     public COMFLOWCheckCodeReturn() {
     }
@@ -136,8 +137,9 @@ AVOIDED		 = {SPACE}*( "abs" | "achar" | "acos" | "acosh" | "adjustl" | "adjustr"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
+		
 		this.parsedFileName = file.toString();
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 		codeLevel.add(1);
 	}
 	
@@ -455,4 +457,9 @@ AVOIDED		 = {SPACE}*( "abs" | "achar" | "acos" | "acosh" | "adjustl" | "adjustr"
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            	{throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMFLOWCheckUser.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMFLOWCheckUser.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMFLOWCheckUser
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -52,6 +53,7 @@ GETUID		 = "GETUID"{SPACE}*\({SPACE}*\)
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	boolean getuid = false;
 	int line = 0;
 	
@@ -61,7 +63,8 @@ GETUID		 = "GETUID"{SPACE}*\({SPACE}*\)
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 		
@@ -166,4 +169,9 @@ GETUID		 = "GETUID"{SPACE}*\({SPACE}*\)
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMFLOWExit.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMFLOWExit.lex
@@ -31,8 +31,9 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMFLOWExit
 %extends AbstractChecker
 %public
-%line
 %column
+%line
+
 %ignorecase
 
 %function run
@@ -59,9 +60,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	List<String> loc = new LinkedList<String>();
 	boolean returnExist = false;
-	private String parsedFileName;
 	
 	public COMFLOWExit(){
 		loc.add(location);
@@ -70,8 +71,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
+		
 		this.parsedFileName = file.toString();
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 %}
 
@@ -164,4 +166,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMFLOWExitLoop.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMFLOWExitLoop.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class COMFLOWExitLoop
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -56,6 +57,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 %{
 	/** Variable used to store violation location and variable involved. **/
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	/** Variable used to store file value and function values associated. **/
 	/** List of string used to store if and do statements. **/
 	List<String> identifiers = new LinkedList<String>();
@@ -70,7 +72,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -194,4 +197,9 @@ END       = [^a-zA-Z0-9\_]("end")[^a-zA-Z0-9\_]{SPACE}*({IF} | {SELECT} | {DO} |
 /*********************/
 /*	ERROR THROWN	 */
 /*********************/
-			[^]			{throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMFLOWFileExistence.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMFLOWFileExistence.lex
@@ -31,8 +31,9 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMFLOWFileExistence
 %extends AbstractChecker
 %public
-%line
 %column
+%line
+
 %ignorecase
 
 %function run
@@ -69,10 +70,10 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	List<String> files = new LinkedList<String>();
 	List<String> chars = new LinkedList<String>();
 	boolean endLine = true;
-	private String parsedFileName;
 	
 	public COMFLOWFileExistence(){
 	}
@@ -81,7 +82,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
 		parsedFileName = file.toString();
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -221,4 +223,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMFLOWFilePath.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMFLOWFilePath.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMFLOWFilePath
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -56,6 +57,7 @@ FILENAME	 = \'[\.]*[a-zA-Z\/][a-zA-Z0-9\_\/]*(\.[a-zA-Z0-9]+)?\'  |
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	boolean lines = false;
 	
 	public COMFLOWFilePath(){
@@ -64,7 +66,8 @@ FILENAME	 = \'[\.]*[a-zA-Z\/][a-zA-Z0-9\_\/]*(\.[a-zA-Z0-9]+)?\'  |
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -150,4 +153,9 @@ FILENAME	 = \'[\.]*[a-zA-Z\/][a-zA-Z0-9\_\/]*(\.[a-zA-Z0-9]+)?\'  |
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMFLOWRecursion.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMFLOWRecursion.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class COMFLOWRecursion
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -49,6 +50,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	
 	public COMFLOWRecursion() {
     }
@@ -56,7 +58,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -105,4 +108,9 @@ RULE_WORD = [^a-zA-Z0-9\_]"recursive"[^a-zA-Z0-9\_]
 <LINE>      	\n             	{yybegin(NEW_LINE);}
 <LINE>      	.              	{}
 
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMINSTBoolNegation.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMINSTBoolNegation.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMINSTBoolNegation
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -55,6 +56,7 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	boolean notFound = false;
 	boolean parFound = false;
 	boolean operFound = false;
@@ -65,7 +67,8 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -143,4 +146,9 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMINSTBrace.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMINSTBrace.lex
@@ -31,8 +31,9 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMINSTBrace
 %extends AbstractChecker
 %public
-%line
 %column
+%line
+
 %ignorecase
 
 %function run
@@ -63,10 +64,10 @@ SPACE		 = [\ \r\t\f]
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	List<Integer> parenthesis = new LinkedList<Integer>();
 	List<Integer> operators   = new LinkedList<Integer>();
 	boolean end = true;
-	private String parsedFileName;
 	
 	public COMINSTBrace(){
 	}
@@ -74,8 +75,9 @@ SPACE		 = [\ \r\t\f]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
+		
 		this.parsedFileName = file.toString();
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -222,4 +224,9 @@ SPACE		 = [\ \r\t\f]
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]           {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMINSTCodeComment.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMINSTCodeComment.lex
@@ -31,8 +31,9 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMINSTCodeComment
 %extends AbstractChecker
 %public
-%line
 %column
+%line
+
 %ignorecase
 
 %function run
@@ -110,6 +111,7 @@ SPACE		 = [\ \r\t\f]
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	List<String> loc = new LinkedList<String>();
 	boolean endHeader = false;
 	boolean params = false;
@@ -122,7 +124,6 @@ SPACE		 = [\ \r\t\f]
    //percent of fault tolerance
      double rateLimit = 0.5;
      
-     private String parsedFileName;
 	 	
 
 	
@@ -132,8 +133,9 @@ SPACE		 = [\ \r\t\f]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
+		
 		this.parsedFileName = file.toString();
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -271,4 +273,9 @@ SPACE		 = [\ \r\t\f]
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMINSTGoTo.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMINSTGoTo.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMINSTGoTo
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -50,6 +51,7 @@ GOTO		 = [^a-zA-Z0-9\_]("go") {SPACE}*("to")
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	
 	public COMINSTGoTo(){
 	}
@@ -57,7 +59,8 @@ GOTO		 = [^a-zA-Z0-9\_]("go") {SPACE}*("to")
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -128,4 +131,9 @@ GOTO		 = [^a-zA-Z0-9\_]("go") {SPACE}*("to")
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMINSTLine.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMINSTLine.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMINSTLine
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -52,6 +53,7 @@ CHAR		 = [a-zA-Z0-9]
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	
 	public COMINSTLine(){
 	}
@@ -59,7 +61,8 @@ CHAR		 = [a-zA-Z0-9]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -135,4 +138,9 @@ CHAR		 = [a-zA-Z0-9]
 /************************/
 /* ERROR STATE	        */
 /************************/
-			[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMINSTLoopCondition.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMINSTLoopCondition.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMINSTLoopCondition
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -62,6 +63,7 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	int par = 0;
 	
 	public COMINSTLoopCondition(){
@@ -70,7 +72,8 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -147,4 +150,9 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]           {throw new JFlexException( new Exception("Illegal character <" + yytext() + "> at line "+yyline+1) );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMNAMEHomonymy.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMNAMEHomonymy.lex
@@ -36,8 +36,9 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMNAMEHomonymy
 %extends AbstractChecker
 %public
-%line
 %column
+%line
+
 %ignorecase
 
 %function run
@@ -70,6 +71,7 @@ SPACE		 = [\ \r\t\f]
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	Map<String, List<String>> hierarchy = new HashMap<String, List<String>>();
 	Map<String, List<String>> variables = new HashMap<String, List<String>>();
 	List<String> locOrder = new LinkedList<String>();
@@ -77,7 +79,6 @@ SPACE		 = [\ \r\t\f]
 	int par = 0;
 	boolean end = true, endStruct = true;
 	
-	private String parsedFileName;
 	
 	public COMNAMEHomonymy(){
 		locOrder.add(location);
@@ -86,8 +87,9 @@ SPACE		 = [\ \r\t\f]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
+		
 		this.parsedFileName = file.toString();
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -289,4 +291,9 @@ SPACE		 = [\ \r\t\f]
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMPRESIndent.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMPRESIndent.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMPRESIndent
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -73,6 +74,7 @@ SPACE		 = [\ \r\t\f]
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	int currentCol = 0;
 	List<Integer> theoricCol = new LinkedList<Integer>();
 	List<Integer> numbers    = new LinkedList<Integer>();
@@ -87,7 +89,8 @@ SPACE		 = [\ \r\t\f]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -269,4 +272,9 @@ SPACE		 = [\ \r\t\f]
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMPRESLengthLine.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMPRESLengthLine.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMPRESLengthLine
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -51,6 +52,7 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	int chars = 1;
 
 	
@@ -60,7 +62,8 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -125,4 +128,9 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMPROJECTHeader.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMPROJECTHeader.lex
@@ -31,8 +31,9 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class COMPROJECTHeader
 %extends AbstractChecker
 %public
-%line
 %column
+%line
+
 %ignorecase
 
 %function run
@@ -61,6 +62,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /* A boolean called comment determines if a comment is set. */
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	List<String> linesType = new LinkedList<String>();
 	List<StringBuilder> locations = new LinkedList<StringBuilder>();
 	List<Integer> lines = new LinkedList<Integer>();
@@ -68,7 +70,6 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	boolean first = true;
 	int errorLine = 0;
 	
-	private String parsedFileName;
 	
 	public COMPROJECTHeader() {
     }
@@ -76,8 +77,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
+		
 		this.parsedFileName = file.toString();
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -281,4 +283,9 @@ SPACE = [\ \f\t]+
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/COMTYPEExpression.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/COMTYPEExpression.lex
@@ -33,6 +33,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMTYPEExpression
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -87,6 +88,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	Map<String, String> variables = new HashMap<String, String>();
 	List<String> arrays = new LinkedList<String>();
 	List<Integer> errors = new LinkedList<Integer>();
@@ -108,7 +110,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -334,4 +337,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]           {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/ExampleRule.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/ExampleRule.lex
@@ -44,6 +44,7 @@ import fr.cnes.analysis.tools.analyzer.datas.Violation;
 %class GeneratedRuleName
 %extends AbstractChecker
 %public
+%column
 %line
 
 /* This three lines are not meant to be modified. */
@@ -86,7 +87,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /* All this code is not meant to be deleted, but some Java program can be added */
 /* in this section.																*/
 %{
-	String location = "MAIN PROGRAM"; 
+	String location = "MAIN PROGRAM";
+    private String parsedFileName; 
   List<Violation> list = new LinkedList<Violation>();
 	
 	public GeneratedRuleName() {
@@ -95,7 +97,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -167,4 +170,4 @@ RULE_WORD = first_word | SECOND_WORD
 <LINE>      	.              	{}
 
 /* Throw error if nothing is catch. */
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				                [^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90BLOCFile.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90BLOCFile.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class F90BLOCFile
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -62,6 +63,7 @@ UNIT		 = (("unit"){SPACE}*("="))?{SPACE}*{VAR}
 %{
 	/** Variable used to store violation location and variable involved. **/
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	/** Variable used to store file value and function values associated. **/
 	/** List of String containing unit variable used for open statement. **/
 	List<String> openUnits = new LinkedList<String>();
@@ -76,7 +78,8 @@ UNIT		 = (("unit"){SPACE}*("="))?{SPACE}*{VAR}
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -209,4 +212,9 @@ UNIT		 = (("unit"){SPACE}*("="))?{SPACE}*{VAR}
 /****************/
 /* THROW ERROR	*/
 /****************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90DATAArray.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90DATAArray.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class F90DATAArray
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -70,7 +71,8 @@ SPACE		 = [\ \t\f\r]
 /* A method called setError with String and integer parameters is used to store	*/
 /* an error found during analysis.												*/
 %{
-	String location = "MAIN PROGRAM"; 
+	String location = "MAIN PROGRAM";
+    private String parsedFileName; 
 	  	/** Parameters' function list **/
   	List<String> parameters = new LinkedList<String>();
   	int parenthese = 0;
@@ -82,7 +84,8 @@ SPACE		 = [\ \t\f\r]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 %}
 
@@ -256,5 +259,9 @@ SPACE		 = [\ \t\f\r]
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
-
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90DATAArrayAccess.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90DATAArrayAccess.lex
@@ -35,6 +35,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F90DATAArrayAccess
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -80,7 +81,8 @@ SPACE		 = [\ \t\f]
 /* A method called setError with String and integer parameters is used to store	*/
 /* an error found during analysis.												*/
 %{
-	String location = "MAIN PROGRAM"; 
+	String location = "MAIN PROGRAM";
+    private String parsedFileName; 
  	/** Arrays declared in the file **/
  	List<String> arrays = new LinkedList<String>();
  	List<String> arraysInd = new LinkedList<String>();
@@ -97,7 +99,8 @@ SPACE		 = [\ \t\f]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -224,4 +227,9 @@ SPACE		 = [\ \t\f]
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90DATAConstant.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90DATAConstant.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F90DATAConstant
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -71,7 +72,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /* A method called setError with String and integer parameters is used to store	*/
 /* an error found during analysis.												*/
 %{
-	String location = "MAIN PROGRAM"; 
+	String location = "MAIN PROGRAM";
+    private String parsedFileName; 
 	
 	public F90DATAConstant() {
     }
@@ -79,7 +81,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 %}
 
@@ -134,4 +137,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90DATAConstantFloat.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90DATAConstantFloat.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class F90DATAConstantFloat
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -75,7 +76,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /* A method called setError with String and integer parameters is used to store	*/
 /* an error found during analysis.												*/
 %{
-	String location = "MAIN PROGRAM"; 
+	String location = "MAIN PROGRAM";
+    private String parsedFileName; 
  	String constant = null;
 	String variable = null;
 	boolean wellDef = false;
@@ -89,7 +91,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -173,4 +176,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90DATADeclaration.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90DATADeclaration.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class F90DATADeclaration	
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -115,7 +116,8 @@ SPACE		 = [\ \t\f\r]
 /* A method called setError with String and integer parameters is used to store	*/
 /* an error found during analysis.												*/
 %{
-	String location = "MAIN PROGRAM"; 
+	String location = "MAIN PROGRAM";
+    private String parsedFileName; 
 	 	int line = 0;
   	/** List of variables**/
   	List<String> variables = new LinkedList<String>();
@@ -133,7 +135,8 @@ SPACE		 = [\ \t\f\r]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	private void comparerError()throws JFlexException{
@@ -315,5 +318,9 @@ SPACE		 = [\ \t\f\r]
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
-
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90DATAFloat.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90DATAFloat.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class F90DATAFloat
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -74,6 +75,7 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 %{
 	/** Variable used to determine violations' location. **/
     String location = "MAIN PROGRAM";
+    private String parsedFileName;
     final List<String> floatList = new LinkedList<String>();
     /** Boolean used to determine if star is used in a write. **/
     boolean star = false;
@@ -96,6 +98,7 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
     public final void setInputFile(final File file)
             throws FileNotFoundException {
         super.setInputFile(file);
+        this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
     }
 %}
@@ -195,4 +198,9 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90DATAParameter.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90DATAParameter.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class F90DATAParameter
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -71,7 +72,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /* A method called setError with String and integer parameters is used to store	*/
 /* an error found during analysis.												*/
 %{
-	String location = "MAIN PROGRAM"; 
+	String location = "MAIN PROGRAM";
+    private String parsedFileName; 
 	boolean integerDef = false;
 	
 	public F90DATAParameter() {
@@ -80,7 +82,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -146,4 +149,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90DESIGNFree.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90DESIGNFree.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class F90DESIGNFree
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -75,7 +76,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /* A method called setError with String and integer parameters is used to store	*/
 /* an error found during analysis.												*/
 %{
-	String location = "MAIN PROGRAM"; 
+	String location = "MAIN PROGRAM";
+    private String parsedFileName; 
  	String alloc = "";
 	
 	public F90DESIGNFree() {
@@ -84,7 +86,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 %}
 
@@ -152,4 +155,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90DESIGNIO.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90DESIGNIO.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class F90DESIGNIO
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -76,7 +77,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /* A method called setError with String and integer parameters is used to store	*/
 /* an error found during analysis.												*/
 %{
-	String location = "MAIN PROGRAM"; 
+	String location = "MAIN PROGRAM";
+    private String parsedFileName; 
  	List<String> unites = new LinkedList<String>();
 	
 	public F90DESIGNIO() {
@@ -85,7 +87,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -172,4 +175,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90DESIGNInclude.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90DESIGNInclude.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class F90DESIGNInclude
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -55,6 +56,7 @@ INCLUDE	 	 = [^a-zA-Z0-9\_]("include"){SPACE}+{STRING}
 %{
 	/** Variable used to store violation location and variable involved. **/
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	/** Variable used to store file value and function values associated. **/
 	/** Used to determine if a comment is before an include declaration. **/
 	boolean comment = false;
@@ -67,7 +69,8 @@ INCLUDE	 	 = [^a-zA-Z0-9\_]("include"){SPACE}+{STRING}
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -134,4 +137,9 @@ INCLUDE	 	 = [^a-zA-Z0-9\_]("include"){SPACE}+{STRING}
 /************************/
 /* THROW ERROR          */
 /************************/
-			[^]           {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90DESIGNInterface.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90DESIGNInterface.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class F90DESIGNInterface
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -61,6 +62,7 @@ ERROR		 = "allocatable" | "allocate" | "assign" | "backspace" | "block" | "call"
 %{
 	/** Variable used to store violation location and variable involved. **/
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	/** Variables to store the error in module definition line**/
 	boolean inter = false;
 	boolean error = false;
@@ -71,7 +73,8 @@ ERROR		 = "allocatable" | "allocate" | "assign" | "backspace" | "block" | "call"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -171,4 +174,9 @@ ERROR		 = "allocatable" | "allocate" | "assign" | "backspace" | "block" | "call"
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90DESIGNObsolete.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90DESIGNObsolete.lex
@@ -33,6 +33,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class F90DESIGNObsolete
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -68,7 +69,8 @@ IF_BRANCH    = [1-9]+[0-9]*{SPACE}*("end"){SPACE}*("if")
 CHAR		 = "character" {SPACE}* \*
 
 %{
-	String location = "MAIN PROGRAM"; 
+	String location = "MAIN PROGRAM";
+    private String parsedFileName; 
 	/** Rule used to assert that arithmetical if is not used. **/
 	AbstractChecker rule1 = new F90DESIGNObsoleteArithmeticalIf();
 	/** Rule used to assert that do loop ending branch is done on a continue or an end do. **/
@@ -103,6 +105,7 @@ CHAR		 = "character" {SPACE}* \*
         this.rule4.setContribution(this.getContribution());
         this.rule4.setInputFile(file);
 		
+        this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
     }
 	
@@ -253,4 +256,9 @@ CHAR		 = "character" {SPACE}* \*
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90DESIGNObsoleteArithmeticalIf.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90DESIGNObsoleteArithmeticalIf.lex
@@ -31,8 +31,9 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F90DESIGNObsoleteArithmeticalIf
 %extends AbstractChecker
 %public
-%line
 %column
+%line
+
 
 %function run
 %yylexthrow JFlexException
@@ -58,6 +59,7 @@ INT			 = [0-9]+
 
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	
 	int bracket = 0;
 	
@@ -67,7 +69,8 @@ INT			 = [0-9]+
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 %}
 
@@ -163,4 +166,9 @@ CONT	  = CONTINUE  | continue
 /*********************/
 /*	ERROR THROWN	 */
 /*********************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90DESIGNObsoleteDoEnding.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90DESIGNObsoleteDoEnding.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F90DESIGNObsoleteDoEnding
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -51,6 +52,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	/** List of labels found during analysis, following a DO. **/
 	List<String> labels = new LinkedList<String>();
 	
@@ -60,7 +62,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	private void addLabel(String label) throws JFlexException {
@@ -182,4 +185,9 @@ INT		  = [0-9]+
 /************************/
 /* THROW ERROR          */
 /************************/
-			[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90DESIGNObsoleteDoReal.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90DESIGNObsoleteDoReal.lex
@@ -33,8 +33,9 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F90DESIGNObsoleteDoReal
 %extends AbstractChecker
 %public
-%line
 %column
+%line
+
 
 %function run
 %yylexthrow JFlexException
@@ -61,6 +62,7 @@ SPACE		 = [\ \t\r]
 
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	
 	
 	public F90DESIGNObsoleteDoReal() {
@@ -69,7 +71,8 @@ SPACE		 = [\ \t\r]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 %}
 
@@ -211,4 +214,9 @@ WRONG_TYPE  = {REAL} 			| {DOUBLE_PREC} | {COMPLEX} | {LOGICAL} | {CHAR}
 /*********************/
 /*	ERROR THROWN	 */
 /*********************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90DESIGNObsoleteDoShared.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90DESIGNObsoleteDoShared.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F90DESIGNObsoleteDoShared
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -53,6 +54,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	
 	List<String> identifiers = new LinkedList<String>();
 	
@@ -62,7 +64,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	private void checkIndentifiers(String id) throws JFlexException {
@@ -132,4 +135,9 @@ INT		  = [0-9]+
 <LINE>      	\n             	{yybegin(NEW_LINE);}
 <LINE>      	.              	{}
 
-				[^]           {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90ERRAllocate.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90ERRAllocate.lex
@@ -35,6 +35,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F90ERRAllocate
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -81,7 +82,8 @@ SPACE		 = [\ \t\f]
 /* A method called setError with String and integer parameters is used to store	*/
 /* an error found during analysis.												*/
 %{
-	String location = "MAIN PROGRAM"; 
+	String location = "MAIN PROGRAM";
+    private String parsedFileName; 
   	String stat = "";
 	boolean ifFound = false;
 	String descr = "";
@@ -92,7 +94,8 @@ SPACE		 = [\ \t\f]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -184,4 +187,9 @@ SPACE		 = [\ \t\f]
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90ERROpenRead.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90ERROpenRead.lex
@@ -35,8 +35,9 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F90ERROpenRead
 %extends AbstractChecker
 %public
-%line
 %column
+%line
+
 %ignorecase
 
 %function run
@@ -78,13 +79,13 @@ IOSTAT 		 = ("iostat") {SPACE}* \= {SPACE}* {VAR}
 /* A method called setError with String and integer parameters is used to store	*/
 /* an error found during analysis.												*/
 %{
-	String location = "MAIN PROGRAM"; 
+	String location = "MAIN PROGRAM";
+    private String parsedFileName; 
  	boolean iostat = false, file = false, add=false;
 	boolean multLines = false;
 	List<String> files = new LinkedList<String>();
 	int errorLine = 0;
 	String descr = "", iostatVal = "";
-	private String parsedFileName;
 	
 	public F90ERROpenRead() {
     }
@@ -92,8 +93,9 @@ IOSTAT 		 = ("iostat") {SPACE}* \= {SPACE}* {VAR}
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
+		
 		this.parsedFileName = file.toString();
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 %}
 
@@ -231,4 +233,9 @@ IOSTAT 		 = ("iostat") {SPACE}* \= {SPACE}* {VAR}
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90INSTAssociated.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90INSTAssociated.lex
@@ -32,6 +32,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class F90INSTAssociated
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -69,6 +70,7 @@ ASSOCIATED	 = ("associated")
 %{
 	/** Variable used to store violation location and variable involved. **/
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	/** Variable used to store file value and function values associated. **/
 	/** List of pointer name and associated boolean, which is true when pointer is assigned to a target. **/
 	Map<String, Boolean> pointers = new HashMap<String, Boolean>();
@@ -81,7 +83,8 @@ ASSOCIATED	 = ("associated")
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -193,4 +196,9 @@ ASSOCIATED	 = ("associated")
 /************************/
 /* THROW ERROR          */
 /************************/
-			[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90INSTEntry.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90INSTEntry.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F90INSTEntry
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -49,7 +50,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 
 %{
 	/** Variable used to store violation location and variable involved. **/
-	String location = "MAIN PROGRAM"; 
+	String location = "MAIN PROGRAM";
+    private String parsedFileName; 
 	
 	public F90INSTEntry() {
     }
@@ -57,7 +59,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}	
 	
 %}
@@ -113,4 +116,9 @@ RULE_WORD = [^a-zA-Z0-9\_]("entry")[^a-zA-Z0-9\_]
 /*********************/
 /*	ERROR THROWN	 */
 /*********************/	
-			[^]	        {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90INSTEquivalence.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90INSTEquivalence.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F90INSTEquivalence
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -54,6 +55,7 @@ EQUIV		 = [^a-zA-Z0-9\_]("equivalence")[^a-zA-Z0-9\_]
 %{
 	/** Variable used to store violation location and variable involved. **/
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	/** Variable used to store file value and function values associated. **/
 	
 	public F90INSTEquivalence() {
@@ -62,7 +64,8 @@ EQUIV		 = [^a-zA-Z0-9\_]("equivalence")[^a-zA-Z0-9\_]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -117,4 +120,9 @@ EQUIV		 = [^a-zA-Z0-9\_]("equivalence")[^a-zA-Z0-9\_]
 /************************/
 /* THROW ERROR          */
 /************************/
-			[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90INSTIf.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90INSTIf.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F90INSTIf
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -58,6 +59,7 @@ BRANCH		 = [^a-zA-Z0-9\_]("exit" | "cycle" | "goto" | "return")[^a-zA-Z0-9\_]
 %{
 	/** Variable used to store violation location and variable involved. **/
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	/** Variable used to store file value and function values associated. **/
 	boolean hasBranch = false;
 	boolean hasThen = false;
@@ -70,7 +72,8 @@ BRANCH		 = [^a-zA-Z0-9\_]("exit" | "cycle" | "goto" | "return")[^a-zA-Z0-9\_]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -148,4 +151,9 @@ BRANCH		 = [^a-zA-Z0-9\_]("exit" | "cycle" | "goto" | "return")[^a-zA-Z0-9\_]
 /****************/
 /* THROW ERROR	*/
 /****************/
-			[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90INSTIntent.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90INSTIntent.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F90INSTIntent
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -76,7 +77,8 @@ SPACE		 = [\ \t\f]
 /* A method called setError with String and integer parameters is used to store	*/
 /* an error found during analysis.												*/
 %{
-	String location = "MAIN PROGRAM"; 
+	String location = "MAIN PROGRAM";
+    private String parsedFileName; 
 	List<String> params = new LinkedList<String>();
 	boolean end = true;
 	boolean intent = false;
@@ -88,7 +90,8 @@ SPACE		 = [\ \t\f]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -200,4 +203,9 @@ SPACE		 = [\ \t\f]
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90INSTNullify.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90INSTNullify.lex
@@ -32,6 +32,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F90INSTNullify
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -55,6 +56,7 @@ NULLIFY		 = [^a-zA-Z0-9\_]("nullify"){SPACE}*("(")
 %{
 	/** Variable used to store violation location and variable involved. **/
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	/** Variable used to store file value and function values associated. **/
 	List<String> pointers = new LinkedList<String>(); 
 	List<Integer> lines = new LinkedList<Integer>();
@@ -67,7 +69,8 @@ NULLIFY		 = [^a-zA-Z0-9\_]("nullify"){SPACE}*("(")
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -166,4 +169,9 @@ NULLIFY		 = [^a-zA-Z0-9\_]("nullify"){SPACE}*("(")
 /************************/
 /* THROW ERROR          */
 /************************/
-			[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90INSTOnly.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90INSTOnly.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class F90INSTOnly
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -55,6 +56,7 @@ ONLY		 = "only"
 %{
 	/** Variable used to store violation location and variable involved. **/
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	/** Variable used to store file value and function values associated. **/
 	List<String> intrinseques =  new LinkedList<String>();
 	boolean comment = false;
@@ -65,7 +67,8 @@ ONLY		 = "only"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -117,4 +120,9 @@ ONLY		 = "only"
 /************************/
 /* THROW ERROR          */
 /************************/
-			[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90INSTOperator.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90INSTOperator.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F90INSTOperator
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -55,6 +56,7 @@ OP_RELAT	 = ".eq." | ".ne." | ".lt." | ".le." | ".gt." | ".ge."
 %{
 	/** Variable used to store violation location and variable involved. **/
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	/** Variable used to store file value and function values associated. **/
 	
 	public F90INSTOperator() {
@@ -63,7 +65,8 @@ OP_RELAT	 = ".eq." | ".ne." | ".lt." | ".le." | ".gt." | ".ge."
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -115,4 +118,9 @@ OP_RELAT	 = ".eq." | ".ne." | ".lt." | ".le." | ".gt." | ".ge."
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]           {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90INSTPointer.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90INSTPointer.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F90INSTPointer
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -57,6 +58,7 @@ TIPUS		 = "type"
 %{
 	/** Variable used to store violation location and variable involved. **/
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	boolean dimension = false, type = false, pointer = false;
 
 	
@@ -66,7 +68,8 @@ TIPUS		 = "type"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -151,4 +154,9 @@ TIPUS		 = "type"
 /************************/
 /* THROW ERROR          */
 /************************/
-			[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90NAMEGenericIntrinsic.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90NAMEGenericIntrinsic.lex
@@ -33,6 +33,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class F90NAMEGenericIntrinsic
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -55,7 +56,8 @@ VAR_PAR	     = {VAR} [\ ]* \(
 STRING		 = \'[^\']*\' | \"[^\"]*\"
 
 %{
-	String location = "MAIN PROGRAM"; 
+	String location = "MAIN PROGRAM";
+    private String parsedFileName; 
  	List<String> intrinseques =  new LinkedList<String>();
 	List<String> intrinsequesGeneriques =  new LinkedList<String>();
 	
@@ -69,7 +71,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -141,4 +144,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90NAMEKeyWords.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90NAMEKeyWords.lex
@@ -35,6 +35,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F90NAMEKeyWords
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -104,7 +105,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 SPACE		 = [\ \t\f]
 
 %{
-	String location = "MAIN PROGRAM"; 
+	String location = "MAIN PROGRAM";
+    private String parsedFileName; 
  	boolean end = true;
 	
 	public F90NAMEKeyWords() {
@@ -113,7 +115,8 @@ SPACE		 = [\ \t\f]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 %}
 
@@ -206,4 +209,9 @@ SPACE		 = [\ \t\f]
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]           {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90PROTOOverload.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90PROTOOverload.lex
@@ -32,6 +32,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class F90PROTOOverload
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -59,6 +60,7 @@ OPERATEUR	 = "+" | "-" | "*" | "/" | "**"
 %{
 	/** Variable used to store violation location and variable involved. **/
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	/** Variable used to store file value and function values associated. **/
 	Map<String, String> operateurs = new HashMap<String, String>();
 	String op;
@@ -70,7 +72,8 @@ OPERATEUR	 = "+" | "-" | "*" | "/" | "**"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -191,4 +194,9 @@ OPERATEUR	 = "+" | "-" | "*" | "/" | "**"
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90REFArray.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90REFArray.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class F90REFArray
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -59,7 +60,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 SPACE		 = [\ \t\f]
 
 %{
-	String location = "MAIN PROGRAM"; 
+	String location = "MAIN PROGRAM";
+    private String parsedFileName; 
 	/** List where to save the name of all the arrays **/
 	List<String> arrays = new LinkedList<String>();
 	/** Variable to print with the error **/
@@ -81,7 +83,8 @@ SPACE		 = [\ \t\f]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -229,4 +232,9 @@ SPACE		 = [\ \t\f]
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90REFInterface.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90REFInterface.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class F90REFInterface
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -74,7 +75,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /* A method called setError with String and integer parameters is used to store	*/
 /* an error found during analysis.												*/
 %{
-	String location = "MAIN PROGRAM"; 
+	String location = "MAIN PROGRAM";
+    private String parsedFileName; 
  	List<String> call     = new LinkedList<String>();
  	List<String> callFrom = new LinkedList<String>();
  	List<String> locList  = new LinkedList<String>();
@@ -90,7 +92,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -204,4 +207,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90REFLabel.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90REFLabel.lex
@@ -32,8 +32,9 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F90REFLabel
 %extends AbstractChecker
 %public
-%line
 %column
+%line
+
 %ignorecase
 
 %function run
@@ -58,6 +59,7 @@ FALSE_END	 = ("end"[\ ]*"if") | ("end"[\ ]*"do") | ("end"[\ ]*"file") | ("end"[\
 %{
 	/** Variable used to store violation location and variable involved. **/
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	/** Variable used to store file value and function values associated. **/
 	/** Boolean to determine if statement is completed. **/
 	Boolean endComplete = false;
@@ -66,7 +68,6 @@ FALSE_END	 = ("end"[\ ]*"if") | ("end"[\ ]*"do") | ("end"[\ ]*"file") | ("end"[\
 	/** Boolean to determine if an IF statement if over. **/
 	boolean endLine = true;
 	
-	private String parsedFileName;
 	
 	public F90REFLabel() {
     }
@@ -74,8 +75,9 @@ FALSE_END	 = ("end"[\ ]*"if") | ("end"[\ ]*"do") | ("end"[\ ]*"file") | ("end"[\
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
+		
 		this.parsedFileName = file.toString();
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -211,4 +213,9 @@ FALSE_END	 = ("end"[\ ]*"if") | ("end"[\ ]*"do") | ("end"[\ ]*"file") | ("end"[\
 /************************/
 /* THROW ERROR          */
 /************************/
-			[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90REFOpen.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90REFOpen.lex
@@ -34,6 +34,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F90REFOpen
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -59,6 +60,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 %{
 	/** Variable used to store violation location and variable involved. **/
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	/** Variable used to store file value and function values associated. **/
 	/** Boolean to determine if FILE is found. **/
 	boolean fileFound = false;
@@ -81,7 +83,8 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -206,4 +209,9 @@ IOSTAT    = "iostat"
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90REFVariable.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90REFVariable.lex
@@ -33,6 +33,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class F90REFVariable
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -61,7 +62,8 @@ CLE			 = "assign" | "backspace" | ("block"){SPACE}*("data") | "close" | "common"
 PARAM		 = \( [^\)]* \)
 
 %{
-	String location = "MAIN PROGRAM"; 
+	String location = "MAIN PROGRAM";
+    private String parsedFileName; 
 	String functionName;
 	Map<String, List<String>> funcCalls = new HashMap<String, List<String>>();
 	Map<String, List<String>> funcDecls = new HashMap<String, List<String>>();
@@ -72,7 +74,8 @@ PARAM		 = \( [^\)]* \)
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -196,4 +199,9 @@ PARAM		 = \( [^\)]* \)
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90TYPEDerivate.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90TYPEDerivate.lex
@@ -31,8 +31,9 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class F90TYPEDerivate
 %extends AbstractChecker
 %public
-%line
 %column
+%line
+
 %ignorecase
 
 %function run
@@ -54,9 +55,9 @@ STRUCT		 = "type"{SPACE}+{VAR}
 END_STRUCT	 = "end"{SPACE}*"type"
 
 %{
-	String location = "MAIN PROGRAM"; 
+	String location = "MAIN PROGRAM";
+    private String parsedFileName; 
      List<String> locations = new LinkedList<String>(); 
-     private String parsedFileName;
 	
 	public F90TYPEDerivate() {
     }
@@ -64,8 +65,9 @@ END_STRUCT	 = "end"{SPACE}*"type"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
+		
 		this.parsedFileName = file.toString();
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 %}
@@ -147,4 +149,9 @@ END_STRUCT	 = "end"{SPACE}*"type"
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90TYPEInteger.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90TYPEInteger.lex
@@ -34,6 +34,7 @@ import fr.cnes.analysis.tools.analyzer.datas.CheckResult;
 %class F90TYPEInteger
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -60,6 +61,7 @@ SELECTED 	 = ("selected_")("int"|"real"|"char")("_kind")
 %{
 	/** Variable used to store violation location and variable involved. **/
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	/** Variable used to store file value and function values associated. **/
 	/** Boolean to determine if it is a real error **/
 	boolean error = false;
@@ -74,7 +76,8 @@ SELECTED 	 = ("selected_")("int"|"real"|"char")("_kind")
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -152,4 +155,9 @@ SELECTED 	 = ("selected_")("int"|"real"|"char")("_kind")
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.fortran90.rules/lex/F90TYPEReal.lex
+++ b/fr.cnes.analysis.tools.fortran90.rules/lex/F90TYPEReal.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class F90TYPEReal
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -55,6 +56,7 @@ ERROR		 = ( "real" | ("double"){SPACE}*("precision") | "complex" )
 %{
 	/** Variable used to store violation location and variable involved. **/
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	/** Boolean to determine if it is a real error **/
 	boolean error = false;
 	/** Boolean to determine if the variable name needs to be saved **/
@@ -68,7 +70,8 @@ ERROR		 = ( "real" | ("double"){SPACE}*("precision") | "complex" )
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -145,4 +148,9 @@ ERROR		 = ( "real" | ("double"){SPACE}*("precision") | "complex" )
 /************************/
 /* THROW ERROR          */
 /************************/
-				[^]            {throw new JFlexException( new Exception("Illegal character <" + yytext() + ">") );}
+				[^]            {
+                                    String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+                                }

--- a/fr.cnes.analysis.tools.shell.metrics/lex/SHMETComplexitySimplified.lex
+++ b/fr.cnes.analysis.tools.shell.metrics/lex/SHMETComplexitySimplified.lex
@@ -36,8 +36,9 @@ import org.eclipse.core.runtime.Path;
 %extends AbstractChecker
 %public
 %ignorecase
-%line
 %column
+%line
+
 
 %function run
 %yylexthrow JFlexException
@@ -71,6 +72,7 @@ ESAC 			= "esac"
 CASE_STATEMENT	=  ({SPACE}*([^\space\(\)\n]*|{VAR})+{SPACE}*)([\|]({SPACE}*([^\space\(\)\n]*|{VAR})+{SPACE}*))*[^\(\)][\)]
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	private Stack<FunctionComplexitySimplified> functionStack = new Stack<>();
 	float mainComplexity = 1;
 	float totalComplexity = 0;
@@ -79,7 +81,7 @@ CASE_STATEMENT	=  ({SPACE}*([^\space\(\)\n]*|{VAR})+{SPACE}*)([\|]({SPACE}*([^\s
 	Stack<String> commandClosureStack = new Stack<>();
 	private static final Logger LOGGER = Logger.getLogger(SHMETComplexitySimplified.class.getName());	
 	
-	private String parsedFileName;
+	
 	
 	public SHMETComplexitySimplified(){
 	}
@@ -87,8 +89,9 @@ CASE_STATEMENT	=  ({SPACE}*([^\space\(\)\n]*|{VAR})+{SPACE}*)([\|]({SPACE}*([^\s
 	@Override
 	public void setInputFile(File file) throws FileNotFoundException {
 		super.setInputFile(file);
+		
 		this.parsedFileName = file.toString();
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	
@@ -534,7 +537,9 @@ CASE_STATEMENT	=  ({SPACE}*([^\space\(\)\n]*|{VAR})+{SPACE}*)([\|]({SPACE}*([^\s
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]             {
-									String errorMessage = "Class: "+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.getInputFile().getAbsolutePath() +"\nat line:"+yyline+" column:"+yycolumn+"\nLast word read : "+yytext();
-                                    throw new JFlexException(new Exception(errorMessage));	
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
 								}

--- a/fr.cnes.analysis.tools.shell.metrics/lex/SHMETLineOfCode.lex
+++ b/fr.cnes.analysis.tools.shell.metrics/lex/SHMETLineOfCode.lex
@@ -37,8 +37,9 @@ import org.eclipse.core.runtime.Path;
 %class SHMETLineOfCode
 %extends AbstractChecker
 %public
-%line
 %column
+%line
+
 
 %function run
 %yylexthrow JFlexException
@@ -67,6 +68,7 @@ FUNCEND			= \} | \) | \)\) | \]\] | "fi" | "esac" | "done"
 
 %{
 	private String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	private List<String> identifiers = new LinkedList<String>();
 	private float lines=0;
 	private boolean emptyLine = true;
@@ -85,7 +87,8 @@ FUNCEND			= \} | \) | \)\) | \]\] | "fi" | "esac" | "done"
 	public void setInputFile(File file) throws FileNotFoundException {
 		super.setInputFile(file);
 		LOGGER.fine("begin method setInputFile");
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 		LOGGER.fine("end method setInputFile");
 	}
 	
@@ -335,8 +338,9 @@ FUNCEND			= \} | \) | \)\) | \]\] | "fi" | "esac" | "done"
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]             {
-									String errorMessage = "Class: "+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.getInputFile().getAbsolutePath() +"\nat line:"+yyline+" column:"+yycolumn+"\nLast word read : "+yytext();
-                                    throw new JFlexException(new Exception(errorMessage));	
-								}
-				
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}				

--- a/fr.cnes.analysis.tools.shell.metrics/lex/SHMETNesting.lex
+++ b/fr.cnes.analysis.tools.shell.metrics/lex/SHMETNesting.lex
@@ -37,8 +37,9 @@ import org.eclipse.core.runtime.Path;
 %class SHMETNesting
 %extends AbstractChecker
 %public
-%line
 %column
+%line
+
 
 %function run
 %yylexthrow JFlexException
@@ -67,6 +68,7 @@ FUNCEND			= \} | \) | \)\) | \]\] | "fi" | "esac" | "done"
 
 %{
 	private String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	private List<String> identifiers = new LinkedList<String>();
 	private Stack<FunctionNesting> functionStack = new Stack<>();
 	private Stack<String> mainNestingStack = new Stack<>();
@@ -82,7 +84,8 @@ FUNCEND			= \} | \) | \)\) | \]\] | "fi" | "esac" | "done"
 	public void setInputFile(File file) throws FileNotFoundException {
 		super.setInputFile(file);
 		LOGGER.fine("begin method setInputFile");
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 		LOGGER.fine("end method setInputFile");
 	}
 	
@@ -326,8 +329,9 @@ FUNCEND			= \} | \) | \)\) | \]\] | "fi" | "esac" | "done"
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]             {
-									String errorMessage = "Class: "+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.getInputFile().getAbsolutePath() +"\nat line:"+yyline+" column:"+yycolumn+"\nLast word read : "+yytext();
-                                    throw new JFlexException(new Exception(errorMessage));	
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
 								}
-				

--- a/fr.cnes.analysis.tools.shell.metrics/lex/SHMETRatioComment.lex
+++ b/fr.cnes.analysis.tools.shell.metrics/lex/SHMETRatioComment.lex
@@ -37,8 +37,9 @@ import org.eclipse.core.runtime.Path;
 %class SHMETRatioComment
 %extends AbstractChecker
 %public
-%line
 %column
+%line
+
 
 %function run
 %yylexthrow JFlexException
@@ -67,6 +68,7 @@ FUNCEND			= \} | \) | \)\) | \]\] | "fi" | "esac" | "done"
 
 %{
 	private String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	private List<String> identifiers = new LinkedList<String>();
 	private float lines=0;
 	private boolean emptyLine = true;
@@ -88,7 +90,8 @@ FUNCEND			= \} | \) | \)\) | \]\] | "fi" | "esac" | "done"
 	public void setInputFile(File file) throws FileNotFoundException {
 		super.setInputFile(file);
 		LOGGER.fine("begin method setInputFile");
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 		LOGGER.fine("end method setInputFile");
 	}
 	
@@ -385,8 +388,9 @@ FUNCEND			= \} | \) | \)\) | \]\] | "fi" | "esac" | "done"
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]             {
-									String errorMessage = "Class: "+this.getClass().getName()+"\nIllegal character <" + yytext() + ">\nFile :"+ this.getInputFile().getAbsolutePath() +"\nat line:"+yyline+" column:"+yycolumn+"\nLast word read : "+yytext();
-                                    throw new JFlexException(new Exception(errorMessage));	
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
 								}
-				

--- a/fr.cnes.analysis.tools.shell.rules/lex/COMDATAInvariant.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/COMDATAInvariant.lex
@@ -33,6 +33,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMDATAInvariant
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -107,6 +108,7 @@ CLE			 = "alias" | "apropos" | "apt-get" | "aptitude" | "ascp" | "aspell" | "awk
 %{
     /* MAINPROGRAM: constant for main program localisation */
     private static final String MAINPROGRAM = "MAIN PROGRAM";
+    private String parsedFileName;
 	private String location = MAINPROGRAM;
 	/* VARIABLE: constant for variable error message */
 	private static final String VARIABLE = " -> The variable ";
@@ -188,7 +190,9 @@ CLE			 = "alias" | "apropos" | "apt-get" | "aptitude" | "ascp" | "aspell" | "awk
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 		
 %}
@@ -268,7 +272,7 @@ CLE			 = "alias" | "apropos" | "apt-get" | "aptitude" | "ascp" | "aspell" | "awk
 									 String var = yytext().substring(varPos, yytext().length()-1);
 									 localAddVar(var);
 									 yybegin(INVARIANT);}
-			 	.              		{}
+	 			[^]              	{}
 		}
 		
 /************************/
@@ -294,4 +298,9 @@ CLE			 = "alias" | "apropos" | "apt-get" | "aptitude" | "ascp" | "aspell" | "awk
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/COMDESIGNActiveWait.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/COMDESIGNActiveWait.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMDESIGNActiveWait
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -51,6 +52,7 @@ ACTWAIT     = "while"{SPACE}*\[{SPACE}*"1"{SPACE}*\]{SPACE}*    |
                                                                 
 %{
     String location = "MAIN PROGRAM";
+    private String parsedFileName;
 
     public COMDESIGNActiveWait() {
     }
@@ -58,6 +60,8 @@ ACTWAIT     = "while"{SPACE}*\[{SPACE}*"1"{SPACE}*\]{SPACE}*    |
     @Override
     public void setInputFile(final File file) throws FileNotFoundException {
         super.setInputFile(file);
+        
+        this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
     }
         
@@ -105,11 +109,16 @@ ACTWAIT     = "while"{SPACE}*\[{SPACE}*"1"{SPACE}*\]{SPACE}*    |
                 {ACTWAIT}       {setError(location,"There is an active wait in this point.", yyline+1); }
                 {STRING}        {}
                 {VAR}           {} /* Clause to match with words */
-                .               {}
+                [^]             {}
         }
 
 
 /************************/
 /* ERROR STATE          */
 /************************/
-             [^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/COMFLOWCaseSwitch.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/COMFLOWCaseSwitch.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMFLOWCaseSwitch
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -50,6 +51,7 @@ ESAC		 = "esac"
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	boolean defaultExpr = false;
 
     public COMFLOWCaseSwitch() {
@@ -58,7 +60,9 @@ ESAC		 = "esac"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 		
 %}
@@ -105,7 +109,7 @@ ESAC		 = "esac"
 			    {STRING}		{}
 			    {CASE}			{defaultExpr=false; yybegin(CONDITIONAL);}
 			    {VAR}			{} /* Clause to match with words that contains "kill" */
-			 	.              	{}
+			 	[^]            	{}
 		}
 		
 /************************/
@@ -123,4 +127,9 @@ ESAC		 = "esac"
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/COMFLOWFileExistence.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/COMFLOWFileExistence.lex
@@ -33,8 +33,9 @@ import java.util.logging.Logger;
 %class COMFLOWFileExistence
 %extends AbstractChecker
 %public
-%line
 %column
+%line
+
 
 %function run
 %yylexthrow JFlexException
@@ -94,6 +95,7 @@ IGNORE		   = {REDIRECT_IGNORE} | {STRING_ESCAPED} | ([\\][\#]) | "ssh"
 	private String location = "MAIN PROGRAM";
     private String parsedFileName;
     
+    
 	List<String> filesExistence = new ArrayList<String>();
 	
 	private String stringBeginner = ""; 
@@ -108,6 +110,8 @@ IGNORE		   = {REDIRECT_IGNORE} | {STRING_ESCAPED} | ([\\][\#]) | "ssh"
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.fine("begin method setInputFile");
+        
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.fine("end method setInputFile");
@@ -200,7 +204,7 @@ IGNORE		   = {REDIRECT_IGNORE} | {STRING_ESCAPED} | ([\\][\#]) | "ssh"
 		 														LOGGER.fine("["+this.parsedFileName+":"+(yyline+1)+":"+yycolumn+"] - YYINITIAL -> STRING (Transition : STRING \""+yytext()+"\" )");
 		 														yybegin(STRING);
 			 												}									
-			 	.              								{}
+			 	[^]            								{}
 			 	
 		}	
 		
@@ -267,4 +271,9 @@ IGNORE		   = {REDIRECT_IGNORE} | {STRING_ESCAPED} | ([\\][\#]) | "ssh"
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/COMINSTBoolNegation.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/COMINSTBoolNegation.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMINSTBoolNegation
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -54,6 +55,7 @@ OPER		 = \&\&	  |  \|\|   | \-"o"	 |  \-"a"
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	/** Bool to knkow if there are open brackets **/
 	int bracket = 0, brace = 0, parenth = 0;
 
@@ -63,7 +65,9 @@ OPER		 = \&\&	  |  \|\|   | \-"o"	 |  \-"a"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 
 		
@@ -111,7 +115,7 @@ OPER		 = \&\&	  |  \|\|   | \-"o"	 |  \-"a"
 				{FUNCT}			{location = yytext().substring(0,yytext().length()-2).trim();}
 				{NOT}			{bracket=0; brace=0; parenth=0; yybegin(LOGICAL);}
 			    {STRING}		{}
-			 	.              	{}
+			 	[^]            	{}
 		}
 		
 /************************/
@@ -135,4 +139,9 @@ OPER		 = \&\&	  |  \|\|   | \-"o"	 |  \-"a"
 /************************/
 /* ERROR STATE	        */
 /************************/
-			[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/COMINSTBrace.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/COMINSTBrace.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMINSTBrace
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -60,6 +61,7 @@ BRACING		 = "expr"	| "let"
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	List<Integer> parenthesis = new LinkedList<Integer>();
 	List<Integer> operators   = new LinkedList<Integer>();
 
@@ -69,7 +71,9 @@ BRACING		 = "expr"	| "let"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	private void addParenthesis(){
@@ -171,7 +175,7 @@ BRACING		 = "expr"	| "let"
 			    "export"		{yybegin(COMMENT);}
 				{BRACING}		{yybegin(BRACE);}
 				{VAR}			{}
-	      		.              	{}
+	      		[^]            	{}
 		}
 		
 /************************/
@@ -192,4 +196,9 @@ BRACING		 = "expr"	| "let"
 /************************/
 /* ERROR STATE	        */
 /************************/
-			[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/COMINSTLine.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/COMINSTLine.lex
@@ -33,8 +33,9 @@ import java.util.logging.Logger;
 %class COMINSTLine
 %extends AbstractChecker
 %public
-%line
 %column
+%line
+
 
 %function run
 %yylexthrow JFlexException
@@ -64,7 +65,8 @@ CONDITIONAL_STRUCT		= [\[][\[]({VAR}|{SPACE}|{VALUE}|{OPERATOR}|{BRACKET})*[\]][
 %{
     private static final Logger LOGGER = Logger.getLogger(COMINSTLine.class.getName());
 	String location = "MAIN PROGRAM";
-    String parsedFileName;
+    private String parsedFileName;
+    
 	
 
     public COMINSTLine() {
@@ -75,6 +77,8 @@ CONDITIONAL_STRUCT		= [\[][\[]({VAR}|{SPACE}|{VALUE}|{OPERATOR}|{BRACKET})*[\]][
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.fine("begin method setInputFile");
+        
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.fine("end method setInputFile");
@@ -167,10 +171,15 @@ CONDITIONAL_STRUCT		= [\[][\[]({VAR}|{SPACE}|{VALUE}|{OPERATOR}|{BRACKET})*[\]][
 			    							LOGGER.fine("["+this.parsedFileName+":"+(yyline+1)+":"+yycolumn+"] - YYINITIAL -> IGNORE (NEW_INSTRUCTION : \""+yytext()+"\")");
 			    							yybegin(IGNORE);
 			    						}
-	      		.              			{}
+	      		[^]            			{}
 		}
 
 /************************/
 /* ERROR STATE	        */
 /************************/
-			[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/COMINSTLoopCondition.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/COMINSTLoopCondition.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMINSTLoopCondition
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -66,6 +67,7 @@ LOOP		 = {WHILE}	| {UNTIL}
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 
     public COMINSTLoopCondition() {
     	
@@ -74,7 +76,9 @@ LOOP		 = {WHILE}	| {UNTIL}
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 			
 %}
@@ -122,7 +126,7 @@ LOOP		 = {WHILE}	| {UNTIL}
 				{FUNCT}			{location = yytext().substring(0,yytext().length()-2).trim();}
 			    {STRING}		{}
 			    {LOOP}			{yybegin(LOOPCONDITION);}
-	      		.              	{}
+	      		[^]            	{}
 		}
 		
 /************************/
@@ -141,4 +145,9 @@ LOOP		 = {WHILE}	| {UNTIL}
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/COMPRESHeader.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/COMPRESHeader.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMPRESHeader
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -51,6 +52,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	List<String> linesType = new LinkedList<String>();
 	List<StringBuilder> locations = new LinkedList<StringBuilder>();
 	List<Integer> lines = new LinkedList<Integer>();
@@ -64,7 +66,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	private void addType(String type, String location, int line){
@@ -191,4 +195,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /************************/
 /* ERROR STATE	        */
 /************************/
-			[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/COMPRESIndent.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/COMPRESIndent.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMPRESIndent
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -61,6 +62,7 @@ IGNORETEXT	 = "<<" {SPACE}* "EOF" [^"<<"]* "EOF" | ` [^`]* `
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	int currentPos = 0, pos = 0; 
 	List<Integer> desiredPos = new ArrayList<Integer>();
 	/* inTabs is true while parsing tabs at the beginning of a line */
@@ -79,7 +81,9 @@ IGNORETEXT	 = "<<" {SPACE}* "EOF" [^"<<"]* "EOF" | ` [^`]* `
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	/** 
@@ -224,4 +228,9 @@ IGNORETEXT	 = "<<" {SPACE}* "EOF" [^"<<"]* "EOF" | ` [^`]* `
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/COMPRESLengthLine.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/COMPRESLengthLine.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMPRESLengthLine
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -49,6 +50,7 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	int length = 0;
 
     public COMPRESLengthLine() {
@@ -58,7 +60,9 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	private void checkLine() throws JFlexException {
@@ -107,4 +111,9 @@ VAR		     = [a-zA-Z][a-zA-Z0-9\_]*
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/COMTYPEExpression.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/COMTYPEExpression.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class COMTYPEExpression
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -62,6 +63,7 @@ EXPR		 = {VARIABLE} {SPACE}+ {OPER} {SPACE}+ ({STRING}|{INT}|{VARIABLE})
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	List<String> chars = new ArrayList<String>();
 	List<String> ints  = new ArrayList<String>();
 	String variableName = "";
@@ -106,7 +108,9 @@ EXPR		 = {VARIABLE} {SPACE}+ {OPER} {SPACE}+ ({STRING}|{INT}|{VARIABLE})
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 			
 %}
@@ -196,4 +200,9 @@ EXPR		 = {VARIABLE} {SPACE}+ {OPER} {SPACE}+ ({STRING}|{INT}|{VARIABLE})
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHDATAIFS.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHDATAIFS.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHDATAIFS
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -53,6 +54,7 @@ IFS			 = "IFS"\=
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 
     public SHDATAIFS() {
     	
@@ -61,7 +63,9 @@ IFS			 = "IFS"\=
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 			
 %}
@@ -117,4 +121,9 @@ IFS			 = "IFS"\=
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHDATAInteger.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHDATAInteger.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHDATAInteger
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -58,6 +59,7 @@ TYPESET		 = "typeset"{SPACE}+\-"i"
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	List<String> integers = new ArrayList<String>();
 
     public SHDATAInteger() {
@@ -67,7 +69,9 @@ TYPESET		 = "typeset"{SPACE}+\-"i"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 			
 %}
@@ -151,4 +155,9 @@ TYPESET		 = "typeset"{SPACE}+\-"i"
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHDESIGNBash.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHDESIGNBash.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHDESIGNBash
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -51,6 +52,7 @@ CORRECT		 = \#\!\/"bin"\/"bash"	|
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 
     public SHDESIGNBash() {
     	
@@ -59,7 +61,9 @@ CORRECT		 = \#\!\/"bin"\/"bash"	|
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 			
 %}
@@ -99,4 +103,9 @@ CORRECT		 = \#\!\/"bin"\/"bash"	|
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHDESIGNOptions.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHDESIGNOptions.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHDESIGNOptions
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -54,6 +55,7 @@ ESAC		 = "esac"
 																
 %{
 	private String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	
 	/* getopts = true if getopts has been found */
 	/* inGetopts = true if we are in the process of examining the different opts */
@@ -76,7 +78,9 @@ ESAC		 = "esac"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 			
 %}
@@ -170,4 +174,9 @@ ESAC		 = "esac"
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHERRHelp.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHERRHelp.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHERRHelp
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -57,6 +58,7 @@ HELP	 	 = "help"
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	/* getopts = true if getopts or getopt has been found */
 	/* inGetopts = true if we are in the process of examining the different opts */
 	/* There will be violations if no getopts has been found at the end (getopts = false) */
@@ -71,7 +73,9 @@ HELP	 	 = "help"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 			
 %}
@@ -154,4 +158,9 @@ HELP	 	 = "help"
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHERRNoPipe.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHERRNoPipe.lex
@@ -33,6 +33,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHERRNoPipe
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -66,6 +67,7 @@ OR			 = \|\|
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	/** Is the state reached inside a case statement */
 	private boolean inCase = false;
 	
@@ -77,7 +79,9 @@ OR			 = \|\|
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 			
 %}
@@ -173,4 +177,9 @@ OR			 = \|\|
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHERRString.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHERRString.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHERRString
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -52,6 +53,7 @@ COMPARISON	 = ("if" | "while") {SPACE}* \[ {SPACE}
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	int brackets = 0;
 	
     public SHERRString() {
@@ -61,7 +63,9 @@ COMPARISON	 = ("if" | "while") {SPACE}* \[ {SPACE}
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 			
 %}
@@ -127,4 +131,9 @@ COMPARISON	 = ("if" | "while") {SPACE}* \[ {SPACE}
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHFLOWCheckArguments.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHFLOWCheckArguments.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHFLOWCheckArguments
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -54,6 +55,7 @@ ARGS		 = "if"{SPACE}+\[{SPACE}+\$\#{SPACE}+{COMP}
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	int lastFunctionLine = 0;
 
     public SHFLOWCheckArguments() {
@@ -63,7 +65,9 @@ ARGS		 = "if"{SPACE}+\[{SPACE}+\$\#{SPACE}+{COMP}
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 			
 %}
@@ -136,4 +140,9 @@ ARGS		 = "if"{SPACE}+\[{SPACE}+\$\#{SPACE}+{COMP}
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHFLOWCheckCodeReturn.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHFLOWCheckCodeReturn.lex
@@ -32,6 +32,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHFLOWCheckCodeReturn
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -52,6 +53,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 																
 %{
 	private String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	/** Map with each function name and if contains a return or not **/
 	private Map<String,Boolean> functions = new HashMap<String,Boolean>();
 	/** The return of the last function is checked: avoid problems with last call **/
@@ -111,7 +113,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 
@@ -169,7 +173,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 			    				} else {
 			    					functionCalled=false;
 			    				}} 
-			 	.              	{}
+			 	[^]            	{}
 		}
 		
 /************************/
@@ -237,4 +241,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHFLOWCheckUser.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHFLOWCheckUser.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHFLOWCheckUser
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -60,6 +61,7 @@ DIRECT_CHECK = {DIRECT_USER} {SPACE}+ {OP} {SPACE}+ {ROOT_VALUE}
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	int errorLine =  0;
 	String errorLocation = "";
 	String checkUser = "";
@@ -71,7 +73,9 @@ DIRECT_CHECK = {DIRECT_USER} {SPACE}+ {OP} {SPACE}+ {ROOT_VALUE}
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	private void checkRootUser(String rootUser) {
@@ -134,7 +138,7 @@ DIRECT_CHECK = {DIRECT_USER} {SPACE}+ {OP} {SPACE}+ {ROOT_VALUE}
 /************************/
 <AVOID>   	
 		{
-			   	.              	{}
+			   	[^]            	{}
 		}
 
 /************************/
@@ -155,4 +159,9 @@ DIRECT_CHECK = {DIRECT_USER} {SPACE}+ {OP} {SPACE}+ {ROOT_VALUE}
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHINSTBasename.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHINSTBasename.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHINSTBasename
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -54,6 +55,7 @@ DIRNAME		 = "dirname"{SPACE}+\$"0" | "dirname"{SPACE}+\"\$"0"\"
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 
     public SHINSTBasename() {
     	
@@ -62,7 +64,9 @@ DIRNAME		 = "dirname"{SPACE}+\$"0" | "dirname"{SPACE}+\"\$"0"\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 			
 %}
@@ -118,4 +122,9 @@ DIRNAME		 = "dirname"{SPACE}+\$"0" | "dirname"{SPACE}+\"\$"0"\"
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHINSTContinue.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHINSTContinue.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHINSTContinue
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -49,6 +50,7 @@ CONTINUE	= "continue"
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 
     public SHINSTContinue() {
     }
@@ -56,7 +58,9 @@ CONTINUE	= "continue"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 		
 %}
@@ -103,11 +107,16 @@ CONTINUE	= "continue"
 				{FUNC}        	{location = yytext(); yybegin(NAMING);}
 			    {CONTINUE}		{setError(location,"The keyword CONTINUE is not allowed.", yyline+1); }
 			    {VAR}			{} /* Clause to match with words that contains "continue" */
-			 	.              	{}
+			 	[^]            	{}
 		}
 
 
 /************************/
 /* ERROR STATE	        */
 /************************/
-			[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHINSTFind.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHINSTFind.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHINSTFind
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -53,6 +54,7 @@ LS			 = "ls" | "/bin/ls"
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 
     public SHINSTFind() {
     	
@@ -61,7 +63,9 @@ LS			 = "ls" | "/bin/ls"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 			
 %}
@@ -117,4 +121,9 @@ LS			 = "ls" | "/bin/ls"
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHINSTGetOpts.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHINSTGetOpts.lex
@@ -31,8 +31,9 @@ import java.util.logging.Logger;
 %class SHINSTGetOpts
 %extends AbstractChecker
 %public
-%line
 %column
+%line
+
 
 %function run
 %yylexthrow JFlexException
@@ -55,7 +56,8 @@ ESCAPE_STRING = [\\]([\']|[\"])
 %{
     private static final Logger LOGGER = Logger.getLogger(SHINSTGetOpts.class.getName());
 	String location = "MAIN PROGRAM";
-    String parsedFileName;
+    private String parsedFileName;
+    
     
     
 	boolean foundGetOpts = false;
@@ -74,6 +76,8 @@ ESCAPE_STRING = [\\]([\']|[\"])
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.fine("begin method setInputFile");
+        
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.fine("end method setInputFile");
@@ -161,7 +165,7 @@ ESCAPE_STRING = [\\]([\']|[\"])
 								 	}	
 							}
 							
-				.			{
+				[^]			{
 								escapeNext=false;
 							}
 	
@@ -209,4 +213,9 @@ ESCAPE_STRING = [\\]([\']|[\"])
 /************************/
 /* ERROR STATE	        */
 /************************/
-			[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHINSTInterpreter.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHINSTInterpreter.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHINSTInterpreter
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -48,6 +49,7 @@ CORRECT		 = [\#][\!][\ ]*[\/]
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 
     public SHINSTInterpreter() {
     	
@@ -56,7 +58,9 @@ CORRECT		 = [\#][\!][\ ]*[\/]
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 			
 %}
@@ -96,4 +100,9 @@ CORRECT		 = [\#][\!][\ ]*[\/]
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHINSTKeywords.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHINSTKeywords.lex
@@ -33,8 +33,9 @@ import java.util.logging.Logger;
 %class SHINSTKeywords
 %extends AbstractChecker
 %public
-%line
 %column
+%line
+
 
 %function run
 %yylexthrow JFlexException
@@ -66,7 +67,8 @@ NO_ERROR = (([a-zA-Z0-9\_]+{KEYWORD}|{KEYWORD}[a-zA-Z0-9\_]+)[\=])| {KEYWORD_VAR
 %{
     private static final Logger LOGGER = Logger.getLogger(SHINSTKeywords.class.getName());
 	String location = "MAIN PROGRAM";
-    String parsedFileName;
+    private String parsedFileName;
+    
     
 	private boolean inString = false, escapeNext=false;
 	private String stringBeginner="", commandBeginner="";
@@ -88,6 +90,8 @@ NO_ERROR = (([a-zA-Z0-9\_]+{KEYWORD}|{KEYWORD}[a-zA-Z0-9\_]+)[\=])| {KEYWORD_VAR
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
         LOGGER.fine("begin method setInputFile");
+        
+        
         this.parsedFileName = file.toString();
         this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
         LOGGER.fine("end method setInputFile");
@@ -275,4 +279,9 @@ NO_ERROR = (([a-zA-Z0-9\_]+{KEYWORD}|{KEYWORD}[a-zA-Z0-9\_]+)[\=])| {KEYWORD_VAR
 /************************/
 /* ERROR STATE	        */
 /************************/
-			[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHINSTLogical.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHINSTLogical.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHINSTLogical
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -56,6 +57,7 @@ ENDCOND		 = "do"		| "then"
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 
     public SHINSTLogical() {
     	
@@ -64,7 +66,9 @@ ENDCOND		 = "do"		| "then"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 			
 %}
@@ -142,4 +146,9 @@ ENDCOND		 = "do"		| "then"
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHINSTPOSIX.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHINSTPOSIX.lex
@@ -33,6 +33,7 @@ import java.util.regex.Matcher;
 %class SHINSTPOSIX
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -95,6 +96,7 @@ VAR_ERROR   = ([\$]{ERROR}) | ([\$][\{]{ERROR}[\}])
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	List<String> variables = new ArrayList<String>();
 	/** The next char must be escaped*/
 	private boolean escapeNext = false;
@@ -131,7 +133,9 @@ VAR_ERROR   = ([\$]{ERROR}) | ([\$][\{]{ERROR}[\}])
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 			
 %}
@@ -276,4 +280,9 @@ VAR_ERROR   = ([\$]{ERROR}) | ([\$][\{]{ERROR}[\}])
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHINSTSetShift.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHINSTSetShift.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHINSTSetShift
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -54,6 +55,7 @@ AVOID		 = "set"{SPACE}+\-"o"{SPACE}+"pipefail"
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 
     public SHINSTSetShift() {
     	
@@ -62,7 +64,9 @@ AVOID		 = "set"{SPACE}+\-"o"{SPACE}+"pipefail"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 			
 %}
@@ -119,4 +123,9 @@ AVOID		 = "set"{SPACE}+\-"o"{SPACE}+"pipefail"
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHINSTVariables.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHINSTVariables.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHINSTVariables
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -57,6 +58,7 @@ VAR_ERROR	 = ([\$]({NAME}|{SHELL_VAR}))
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	private boolean goodPractice = false;
 	private boolean escapeNext = true;
 	private String stringBeginner = "";
@@ -67,7 +69,9 @@ VAR_ERROR	 = ([\$]({NAME}|{SHELL_VAR}))
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 			
 %}
@@ -207,4 +211,9 @@ VAR_ERROR	 = ([\$]({NAME}|{SHELL_VAR}))
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHIORedirect.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHIORedirect.lex
@@ -49,6 +49,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHIORedirect
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -75,6 +76,7 @@ REDIRECT 		= {REDIRECT_RIGHT}|{REDIRECT_LEFT}|{REDIRECT_RL}
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	List<String> redirections = new ArrayList<String>();
 	private boolean isLastLineCommented = false;
 	private boolean errorReported=false;
@@ -86,7 +88,9 @@ REDIRECT 		= {REDIRECT_RIGHT}|{REDIRECT_LEFT}|{REDIRECT_RL}
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 			
 %}
@@ -153,4 +157,9 @@ REDIRECT 		= {REDIRECT_RIGHT}|{REDIRECT_LEFT}|{REDIRECT_RL}
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHMETLimitAWK.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHMETLimitAWK.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHMETLimitAWK
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -50,6 +51,7 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	int actions=0, sym=0;
 	int lineError=0;
 	
@@ -60,7 +62,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 			
 %}
@@ -128,4 +132,9 @@ STRING		 = \'[^\']*\' | \"[^\"]*\"
 /************************/
 /* ERROR STATE	        */
 /************************/
-			[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHMETLimitSed.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHMETLimitSed.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHMETLimitSed
 %extends AbstractChecker
 %public
+%column
 %line
 
 %function run
@@ -53,6 +54,7 @@ OPTION		 = "-e"		| "--expression" 	| "-f"		| "--file"		|
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	int actions=0, linesSed=0;
 	int lineError=0;
 	
@@ -63,7 +65,9 @@ OPTION		 = "-e"		| "--expression" 	| "-f"		| "--file"		|
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 			
 %}
@@ -143,4 +147,9 @@ OPTION		 = "-e"		| "--expression" 	| "-f"		| "--file"		|
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHMETPipeLine.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHMETPipeLine.lex
@@ -31,6 +31,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHMETPipeLine
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -51,6 +52,7 @@ PIPELINE	 = \|{SPACE}	| \|\n		| \|\&
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 	int bracket = 0;
 	String type = "";
 	/** For each line a string that represent the line type: comment, empty, line **/
@@ -63,7 +65,9 @@ PIPELINE	 = \|{SPACE}	| \|\n		| \|\&
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 	
 	/**
@@ -155,4 +159,9 @@ PIPELINE	 = \|{SPACE}	| \|\n		| \|\&
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHREFExport.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHREFExport.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHREFExport
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -53,6 +54,7 @@ EXPORT		 = "export"{SPACE}+\-"f"{SPACE}+{VAR}
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 
     public SHREFExport() {
     	
@@ -61,7 +63,9 @@ EXPORT		 = "export"{SPACE}+\-"f"{SPACE}+{VAR}
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 			
 %}
@@ -116,4 +120,9 @@ EXPORT		 = "export"{SPACE}+\-"f"{SPACE}+{VAR}
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.shell.rules/lex/SHSYNCSignals.lex
+++ b/fr.cnes.analysis.tools.shell.rules/lex/SHSYNCSignals.lex
@@ -30,6 +30,7 @@ import fr.cnes.analysis.tools.analyzer.exception.JFlexException;
 %class SHSYNCSignals
 %extends AbstractChecker
 %public
+%column
 %line
 %ignorecase
 
@@ -52,6 +53,7 @@ TRAP		 = "trap"
 																
 %{
 	String location = "MAIN PROGRAM";
+    private String parsedFileName;
 
     public SHSYNCSignals() {
     	
@@ -60,7 +62,9 @@ TRAP		 = "trap"
 	@Override
 	public void setInputFile(final File file) throws FileNotFoundException {
 		super.setInputFile(file);
-		this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
+		
+        this.parsedFileName = file.toString();
+        this.zzReader = new FileReader(new Path(file.getAbsolutePath()).toOSString());
 	}
 			
 %}
@@ -126,4 +130,9 @@ TRAP		 = "trap"
 /************************/
 /* ERROR STATE	        */
 /************************/
-				[^]            {}
+				[^]            {
+									String parsedWord = "Word ["+yytext()+"], code  [" + toASCII(yytext()) + "]";
+				                    final String errorMessage = "Analysis failure : Your file could not be analyzed. Please verify that it was encoded in an UNIX format.";
+				                    throw new JFlexException(this.getClass().getName(), parsedFileName,
+				                                    errorMessage, parsedWord, yyline, yycolumn);
+								}

--- a/fr.cnes.analysis.tools.ui/src/fr/cnes/analysis/tools/ui/handler/AnalysisHandler.java
+++ b/fr.cnes.analysis.tools.ui/src/fr/cnes/analysis/tools/ui/handler/AnalysisHandler.java
@@ -131,6 +131,12 @@ public class AnalysisHandler extends UIAndCommandAbstractHandler {
                                 AnalysisHandler.updateViolationsView(resultsViolation);
                                 AnalysisHandler.updateMetricsView(resultsMetric);
                                 AnalysisHandler.insertMarkers(results);
+                            } else {
+                                MessageDialog.openError(
+                                                PlatformUI.getWorkbench().getActiveWorkbenchWindow()
+                                                                .getShell(),
+                                                "i-Code CNES - Analysis failure",
+                                                analysisJob.getResult().getMessage());
                             }
                         }
                     });
@@ -143,7 +149,7 @@ public class AnalysisHandler extends UIAndCommandAbstractHandler {
             // Launching the analysis.
             analysisJob.schedule();
         } catch (EmptySelectionException | CoreException exception) {
-            MessageDialog.openWarning(HandlerUtil.getActiveShell(event), "Core exception",
+            MessageDialog.openWarning(HandlerUtil.getActiveShell(event), "i-Code CNES - Warning",
                             exception.getMessage());
         }
         LOGGER.exiting(this.getClass().getName(), METHOD, null);

--- a/fr.cnes.analysis.tools.ui/src/fr/cnes/analysis/tools/ui/handler/AnalysisJob.java
+++ b/fr.cnes.analysis.tools.ui/src/fr/cnes/analysis/tools/ui/handler/AnalysisJob.java
@@ -73,6 +73,7 @@ public class AnalysisJob extends Job {
         METHOD = "run";
         LOGGER.entering(this.getClass().getName(), METHOD, monitor);
         IStatus status = Status.OK_STATUS;
+        monitor.setTaskName("Analyzing files...");
         try {
             this.checks = analyzer.check(inputFiles, languageIds, excludedIds);
         } catch (IOException | JFlexException exception) {


### PR DESCRIPTION
## Changelog
* `JFlexException` thrown by lexers has been improved to : ( #50 )
  * Raise the following information from failure : 
    * Checker identifier;
    * Parsed file;
    * Line & Column of the parser;
    * Last word parsed with the value of each character of the string causing the failure. *This can be usefull to detect problems from carriage return or form-feed which can't be seen by the user reading the exception.*
  * Throw a more informative message using raised information.
* `Analyzer` was corrected to fully re-throw `JFlexException` from `CallableChecker` using `java.util.concurrent.ExecutionException`. 
* `AnalysisHandler` dialogMessage were improved to show the full message from `JFlexException`
* **Shell** were edited to throw `JFlexException` when reaching *ERROR STATE*. For 44 of them, this was causing execution problem which had to be fixed by editing some other state. There is still *3 shell lexers* which do not throw `JFlexException` when reaching *ERROR STATE* : 
  * COM.NAME.Homonymy
  * COM.DATA.Initialisation
  * COM.FLOW.Recursion
* Arrays, list, and stack use of the 185 lexers were checked and corrected when required to avoid `OutOfBoundArrayException`. ( #47 ) 
